### PR TITLE
heuristics with failures

### DIFF
--- a/bin/gorgon
+++ b/bin/gorgon
@@ -12,8 +12,14 @@ require 'gorgon/settings/initial_files_creator'
 
 WELCOME_MSG = "Welcome to Gorgon #{Gorgon::VERSION}"
 
-def start
-  o = Originator.new
+def extract_options(argv)
+  options, argv = argv.partition{|arg| /^-/.match(arg)}
+  options.map!{|o| o.gsub(/[^0-9a-z ]/i, '').to_sym} # change to symbols
+  return [ Hash[options.map{|o| [o, true]}], argv ]
+end
+
+def start(options)
+  o = Originator.new(options)
   o.originate
 end
 
@@ -63,6 +69,9 @@ end
 def usage
   #print instructions on how to use gorgon
   puts "\tstart - remotely runs all tests specified in gorgon.json"
+  puts "\t      - options:"
+  puts "\t          1.) --failures - runs only previously failed tests from runtime_file"
+  puts "\t                         - note: will not update the runtime_file"
   puts "\tlisten - starts a listener process using the settings in gorgon_listener.json"
   puts "\tping - pings listeners and shows hosts and gorgon's version they are running"
   puts "\tinit [rails] - create initial files for current project"
@@ -74,11 +83,13 @@ end
 
 puts WELCOME_MSG
 
-case ARGV[0]
+options, argv = extract_options(ARGV)
+
+case argv[0]
 when nil
-  start
+  start(options)
 when "start"
-  start
+  start(options)
 when "listen"
   listen
 when "start_rsync"
@@ -103,3 +114,4 @@ else
   usage
   exit 1
 end
+

--- a/lib/gorgon/job_state.rb
+++ b/lib/gorgon/job_state.rb
@@ -103,6 +103,10 @@ class JobState
     @state == :cancelled
   end
 
+  def failed_test? payload
+    payload[:type] == "fail" || payload[:type] == "crash"
+  end
+
   private
 
   def file_started_update_host_state payload
@@ -120,7 +124,4 @@ class JobState
     puts "NOTICE: JobState#file_finished called after job was cancelled" if is_job_cancelled?
   end
 
-  def failed_test? payload
-    payload[:type] == "fail" || payload[:type] == "crash"
-  end
 end

--- a/lib/gorgon/runtime_recorder.rb
+++ b/lib/gorgon/runtime_recorder.rb
@@ -11,14 +11,17 @@ class RuntimeRecorder
   end
 
   def update payload
-    @records[payload[:filename]] = payload[:runtime] if payload[:action] == "finish"
+    if payload[:action] == "finish"
+      type = @job_state.failed_test?(payload) ? :failed : :passed
+      @records[payload[:filename]] = [type, payload[:runtime]]
+    end
     self.write_records_to_file if @job_state.is_job_complete?
   end
 
   def write_records_to_file
     return if @runtime_filename.empty?
     make_directories
-    @records = Hash[@records.sort_by{|filename, runtime| -1*runtime}]
+    sort_records
     File.open(@runtime_filename, 'w') do |f|
       f.write(Yajl::Encoder.encode(@records, pretty: true))
     end
@@ -26,6 +29,13 @@ class RuntimeRecorder
 
 
   private
+
+  def sort_records
+    @records = Hash[@records.sort_by{|filename, value| [
+      (value[0] == :failed) ? 0 : 1,   # prioritize failed tests
+      -1*value[1],   # prioritize tests with longer runtime
+    ]}]
+  end
 
   def make_directories
     dirname = File.dirname(@runtime_filename)

--- a/spec/runtime_file_reader_spec.rb
+++ b/spec/runtime_file_reader_spec.rb
@@ -3,14 +3,23 @@ require 'yajl'
 
 describe RuntimeFileReader do
 
-  describe "#old_files" do
-    let(:runtime_filename){ "runtime_file.json" }
+  let(:runtime_filename){ "runtime_file.json" }
 
+  describe "#old_files" do
     it "should read runtime_file" do
       File.stub(:file?).and_return(true)
       runtime_file_reader = RuntimeFileReader.new(runtime_filename)
       File.should_receive(:open).with(runtime_filename, 'r')
       runtime_file_reader.old_files
+    end
+
+    it "should return only failed tests if options[:failures]" do
+      old_tests = {"test_a.rb"=>[:failed, 0.2], "test_b.rb"=>[:failed, 0.1], "test_c.rb"=>[:passed, 0.3]}
+      File.should_receive(:file?).and_return(true)
+      runtime_file_reader = RuntimeFileReader.new(runtime_filename, {failures: true})
+      File.should_receive(:open).and_yield(mock('file'))
+      Yajl::Parser.any_instance.stub(:parse).and_return(old_tests)
+      expect(runtime_file_reader.old_files).to eq(["test_a.rb", "test_b.rb"])
     end
 
     it "should return empty array if runtime_file is invalid" do
@@ -19,6 +28,7 @@ describe RuntimeFileReader do
       File.should_not_receive(:open)
       runtime_file_reader.old_files
     end
+
   end
 
 
@@ -26,7 +36,7 @@ describe RuntimeFileReader do
     let (:old_files){ [ "old_a.rb", "old_b.rb", "old_c.rb"] }
 
     before do
-      @runtime_file_reader = RuntimeFileReader.new "runtime_file.json"
+      @runtime_file_reader = RuntimeFileReader.new runtime_filename
       @runtime_file_reader.stub(:old_files).and_return old_files
     end
 
@@ -42,6 +52,14 @@ describe RuntimeFileReader do
       sorted_files = @runtime_file_reader.sorted_files(current_spec_files)
       expect(sorted_files.first(2)).to eq(["old_a.rb", "old_c.rb"])
       expect(sorted_files.last(1)).to eq(["new_a.rb"])
+    end
+
+    it "should only include files that are in old failed files and current files if options[:failures]" do
+      runtime_file_reader = RuntimeFileReader.new runtime_filename, {failures: true}
+      runtime_file_reader.stub(:old_files).and_return old_files
+      current_spec_files = ["new_a.rb", "old_a.rb", "old_c.rb"]
+      sorted_files = runtime_file_reader.sorted_files(current_spec_files)
+      expect(sorted_files).to eq(["old_a.rb", "old_c.rb"])
     end
   end
 


### PR DESCRIPTION
"It will first run all files that failed during last run in runtime order, and then all the files that passed in runtime order as well."

Options:
`gorgon --failures` - runs the failed tests only based on runtime_file; the runtime_file will not be updated