### PR TITLE
Gorgon originator exits with 0 when it crashes due to unhandled exception

### DIFF
--- a/lib/gorgon/originator.rb
+++ b/lib/gorgon/originator.rb
@@ -30,13 +30,14 @@ class Originator
       publish
       @logger.log "Originator finished successfully"
     rescue StandardError
-      puts "Unhandled exception in originator:"
-      puts $!.message
-      puts $!.backtrace.join("\n")
-      puts "----------------------------------"
-      puts "Now attempting to cancel the job."
+      $stderr.puts "Unhandled exception in originator:"
+      $stderr.puts $!.message
+      $stderr.puts $!.backtrace.join("\n")
+      $stderr.puts "----------------------------------"
+      $stderr.puts "Now attempting to cancel the job."
       @logger.log_error "Unhandled Exception!" if @logger
       cancel_job
+      exit 2
     end
   end
 

--- a/spec/originator_spec.rb
+++ b/spec/originator_spec.rb
@@ -76,6 +76,23 @@ describe Originator do
     end
   end
 
+  describe "#originate" do
+    before do
+      stub_methods
+    end
+
+    it "exits with a non-zero status code when the originator crashes" do
+      originator_logger.stub(:log_error)
+      $stderr = StringIO.new # slurp up the error output so we don't pollute the rsync run
+      CallbackHandler.any_instance.should_receive(:before_originate).and_throw("I'm an unhandled exception")
+
+      expect { @originator.originate }.to raise_error(SystemExit) do |error|
+        error.success?.should be_false
+      end
+      $stderr = STDERR
+    end
+  end
+
   describe "#cancel_job" do
     before do
       stub_methods


### PR DESCRIPTION
```
root@3dce1a9a172a:/builds/2af79770/0/RelEng/PackManager-Test# gorgon 
Welcome to Gorgon 0.10.4
Unhandled exception in originator:
404 Resource Not Found
[stack trace output that is not relevant to this specific issue]
----------------------------------
Now attempting to cancel the job.
root@3dce1a9a172a:/builds/2af79770/0/RelEng/PackManager-Test# echo $? 
0
```

Ideally gorgon should exit with something else when it crashes so that scripts are better able to detect failures and bail out.