### PR TITLE
Non zero exit status for spec failure

### DIFF
--- a/bin/gorgon
+++ b/bin/gorgon
@@ -16,7 +16,7 @@ WELCOME_MSG = "Welcome to Gorgon #{Gorgon::VERSION}"
 
 def start
   o = Originator.new
-  o.originate
+  exit o.originate
 end
 
 def listen
@@ -77,7 +77,7 @@ end
 case ARGV[0] # special case for 'version', because we don't need the welcome message telling us the version when we're explicitly asking for it
 when "version", "--version"
   puts Gorgon::VERSION
-  exit 0
+  exit
 end
 
 puts WELCOME_MSG
@@ -87,7 +87,7 @@ when nil
   start
 when "help", "--help"
   usage
-  exit 0
+  exit
 when "start"
   start
 when "listen"

--- a/lib/gorgon/originator.rb
+++ b/lib/gorgon/originator.rb
@@ -19,9 +19,9 @@ class Originator
   include Configuration
 
   SPEC_SUCCESS_EXIT_STATUS = 0
-  SYNC_ERROR_EXIT_STATUS = 1
-  ERROR_EXIT_STATUS = 2
-  SPEC_FAILURE_EXIT_STATUS = 3
+  SPEC_FAILURE_EXIT_STATUS = 1
+  SYNC_ERROR_EXIT_STATUS = 2
+  ERROR_EXIT_STATUS = 3
 
 
   def initialize
@@ -58,6 +58,8 @@ class Originator
   end
 
   def publish
+    exit_status = SPEC_SUCCESS_EXIT_STATUS
+
     @logger = OriginatorLogger.new configuration[:originator_log_file]
 
     if files.empty?
@@ -75,7 +77,7 @@ class Originator
       publish_files_and_job
 
       @protocol.receive_payloads do |payload|
-        handle_reply(payload)
+        exit_status |= handle_reply(payload)
       end
 
       @protocol.receive_new_listener_notifications do |payload|
@@ -84,7 +86,7 @@ class Originator
     end
 
     callback_handler.after_job_finishes
-    SPEC_SUCCESS_EXIT_STATUS
+    exit_status
   end
 
   def publish_files_and_job
@@ -146,6 +148,7 @@ class Originator
     # ap payload
 
     cleanup_if_job_complete
+    exit_status(payload)
   end
 
   def handle_new_listener_notification(payload)
@@ -188,6 +191,11 @@ class Originator
   end
 
   private
+
+  def exit_status(payload)
+    return SPEC_FAILURE_EXIT_STATUS if ["crash", "exception", "fail"].include?(payload[:type])
+    SPEC_SUCCESS_EXIT_STATUS
+  end
 
   def sync_configuration
     configuration[:job].


### PR DESCRIPTION
This PR propagates the results returned by the payloads to the shell.
The idea is that `gorgon` could be scripted and used from the shell to know if the specs failewd or not, this can be very handy when running from CI job.

There is, however, a **breaking change**. I've switched the meaning of some of the error return statuses to make the bitwise operation among then more intuitive. The idea is:
`SPEC_FAILURE_EXIT_STATUS | SYNC_ERROR_EXIT_STATUS = ERROR_EXIT_STATUS`
where `ERROR_EXIT_STATUS` is a generic error that could represent multiple ones.

This should only matter if someone was actually using the specific numeric value in error cases.
Reverting this and keeping backwards compatibility is simple, so I wanted to first propose the breaking changes.

Before the PR (the arrow in zsh is green after a spec failure):
<img width="638" alt="screen shot 2016-10-27 at 1 20 49 pm" src="https://cloud.githubusercontent.com/assets/20668517/19777901/4b4f6934-9c48-11e6-9e3f-389e41268085.png">

After the PR (the arrow in zsh is red after a spec failure):
<img width="659" alt="screen shot 2016-10-27 at 1 21 15 pm" src="https://cloud.githubusercontent.com/assets/20668517/19777906/53071d52-9c48-11e6-8a4f-e8769ff79200.png">

