### PR TITLE
Put all classes and modules under Gorgon namespace.

### DIFF
--- a/lib/gorgon/amqp_service.rb
+++ b/lib/gorgon/amqp_service.rb
@@ -1,39 +1,41 @@
 require 'gorgon_bunny/lib/gorgon_bunny'
 require 'yajl'
 
-class AmqpQueueDecorator
-  def initialize queue
-    @queue = queue
+module Gorgon
+  class AmqpQueueDecorator
+    def initialize queue
+      @queue = queue
+    end
+
+    def pop
+      m = @queue.pop
+      payload = m[2]
+      return payload
+    end
   end
 
-  def pop
-    m = @queue.pop
-    payload = m[2]
-    return payload
-  end
-end
+  class AmqpExchangeDecorator
+    def initialize exchange
+      @exchange = exchange
+    end
 
-class AmqpExchangeDecorator
-  def initialize exchange
-    @exchange = exchange
-  end
-
-  def publish msg
-    serialized_msg = Yajl::Encoder.encode(msg)
-    @exchange.publish serialized_msg
-  end
-end
-
-class AmqpService
-  def initialize connection_config
-    @connection_config = connection_config.merge(:spec => "09")
+    def publish msg
+      serialized_msg = Yajl::Encoder.encode(msg)
+      @exchange.publish serialized_msg
+    end
   end
 
-  def start_worker file_queue_name, reply_exchange_name
-    GorgonBunny.run @connection_config do |b|
-      queue = b.queue(file_queue_name, :auto_delete => true)
-      exchange = b.exchange(reply_exchange_name, :auto_delete => true)
-      yield AmqpQueueDecorator.new(queue), AmqpExchangeDecorator.new(exchange)
+  class AmqpService
+    def initialize connection_config
+      @connection_config = connection_config.merge(:spec => "09")
+    end
+
+    def start_worker file_queue_name, reply_exchange_name
+      GorgonBunny.run @connection_config do |b|
+        queue = b.queue(file_queue_name, :auto_delete => true)
+        exchange = b.exchange(reply_exchange_name, :auto_delete => true)
+        yield AmqpQueueDecorator.new(queue), AmqpExchangeDecorator.new(exchange)
+      end
     end
   end
 end

--- a/lib/gorgon/callback_handler.rb
+++ b/lib/gorgon/callback_handler.rb
@@ -1,35 +1,37 @@
-class CallbackHandler
-  def initialize(config)
-    @config = config || {}
-    load(@config[:callbacks_class_file]) if @config[:callbacks_class_file]
-  end
+module Gorgon
+  class CallbackHandler
+    def initialize(config)
+      @config = config || {}
+      load(@config[:callbacks_class_file]) if @config[:callbacks_class_file]
+    end
 
-  def before_originate
-    cluster_id = Gorgon.callbacks.before_originate
-    return cluster_id if cluster_id.is_a?(String)
-  end
+    def before_originate
+      cluster_id = Gorgon.callbacks.before_originate
+      return cluster_id if cluster_id.is_a?(String)
+    end
 
-  def after_sync
-    Gorgon.callbacks.after_sync
-  end
+    def after_sync
+      Gorgon.callbacks.after_sync
+    end
 
-  def before_creating_workers
-    Gorgon.callbacks.before_creating_workers
-  end
+    def before_creating_workers
+      Gorgon.callbacks.before_creating_workers
+    end
 
-  def before_start
-    Gorgon.callbacks.before_start
-  end
+    def before_start
+      Gorgon.callbacks.before_start
+    end
 
-  def after_creating_workers
-    Gorgon.callbacks.after_creating_workers
-  end
+    def after_creating_workers
+      Gorgon.callbacks.after_creating_workers
+    end
 
-  def after_complete
-    Gorgon.callbacks.after_complete
-  end
+    def after_complete
+      Gorgon.callbacks.after_complete
+    end
 
-  def after_job_finishes
-    Gorgon.callbacks.after_job_finishes
+    def after_job_finishes
+      Gorgon.callbacks.after_job_finishes
+    end
   end
 end

--- a/lib/gorgon/colors.rb
+++ b/lib/gorgon/colors.rb
@@ -1,5 +1,7 @@
-module Colors
-  FILENAME = :light_cyan
-  HOST = :light_blue
-  COMMAND = :yellow
+module Gorgon
+  module Colors
+    FILENAME = :light_cyan
+    HOST = :light_blue
+    COMMAND = :yellow
+  end
 end

--- a/lib/gorgon/configuration.rb
+++ b/lib/gorgon/configuration.rb
@@ -1,9 +1,11 @@
 require "yajl"
 
-module Configuration
-  extend self
-  def load_configuration_from_file(filename)
-    file = File.new(filename, "r")
-    Yajl::Parser.new(:symbolize_keys => true).parse(file)
+module Gorgon
+  module Configuration
+    extend self
+    def load_configuration_from_file(filename)
+      file = File.new(filename, "r")
+      Yajl::Parser.new(:symbolize_keys => true).parse(file)
+    end
   end
 end

--- a/lib/gorgon/crash_reporter.rb
+++ b/lib/gorgon/crash_reporter.rb
@@ -1,19 +1,21 @@
-module CrashReporter
-  OUTPUT_LINES_TO_REPORT = 70
+module Gorgon
+  module CrashReporter
+    OUTPUT_LINES_TO_REPORT = 70
 
-  def report_crash reply_exchange, info
-    stdout = `tail -n #{OUTPUT_LINES_TO_REPORT} #{info[:out_file]}`
-    stderr = `cat #{info[:err_file]}` + \
-    info[:footer_text]
+    def report_crash reply_exchange, info
+      stdout = `tail -n #{OUTPUT_LINES_TO_REPORT} #{info[:out_file]}`
+      stderr = `cat #{info[:err_file]}` + \
+        info[:footer_text]
 
-    send_crash_message reply_exchange, stdout, stderr
+      send_crash_message reply_exchange, stdout, stderr
 
-    "#{stdout}\n#{stderr}"
-  end
+      "#{stdout}\n#{stderr}"
+    end
 
-  def send_crash_message reply_exchange, output, error
-    reply = {:type => :crash, :hostname => Socket.gethostname,
-      :stdout => output, :stderr => error}
-    reply_exchange.publish(Yajl::Encoder.encode(reply))
+    def send_crash_message reply_exchange, output, error
+      reply = {:type => :crash, :hostname => Socket.gethostname,
+               :stdout => output, :stderr => error}
+      reply_exchange.publish(Yajl::Encoder.encode(reply))
+    end
   end
 end

--- a/lib/gorgon/failures_printer.rb
+++ b/lib/gorgon/failures_printer.rb
@@ -1,40 +1,41 @@
 require 'yajl'
 
-class FailuresPrinter
-  DEFAULT_OUTPUT_FILE = "/tmp/gorgon-failed-files.json"
+module Gorgon
+  class FailuresPrinter
+    DEFAULT_OUTPUT_FILE = "/tmp/gorgon-failed-files.json"
 
-  attr_reader :output_file
+    attr_reader :output_file
 
-  def initialize(configuration, job_state)
-    @job_state = job_state
-    @job_state.add_observer(self)
-    @output_file = configuration.fetch(:failed_files) { DEFAULT_OUTPUT_FILE }
-  end
-
-  def update payload
-    return unless @job_state.is_job_complete? || @job_state.is_job_cancelled?
-
-    File.open(@output_file, 'w+') do |fd|
-      fd.write(Yajl::Encoder.encode(failed_files + unfinished_files))
+    def initialize(configuration, job_state)
+      @job_state = job_state
+      @job_state.add_observer(self)
+      @output_file = configuration.fetch(:failed_files) { DEFAULT_OUTPUT_FILE }
     end
-  end
 
-  private
+    def update payload
+      return unless @job_state.is_job_complete? || @job_state.is_job_cancelled?
 
-  def failed_files
-    failed_files = []
-    @job_state.each_failed_test do |test|
-      failed_files << "#{test[:filename]}"
+      File.open(@output_file, 'w+') do |fd|
+        fd.write(Yajl::Encoder.encode(failed_files + unfinished_files))
+      end
     end
-    failed_files
-  end
 
-  def unfinished_files
-    unfinished_files = []
-    @job_state.each_running_file do |hostname, filename|
-      unfinished_files << "#{filename}"
+    private
+
+    def failed_files
+      failed_files = []
+      @job_state.each_failed_test do |test|
+        failed_files << "#{test[:filename]}"
+      end
+      failed_files
     end
-    unfinished_files
+
+    def unfinished_files
+      unfinished_files = []
+      @job_state.each_running_file do |hostname, filename|
+        unfinished_files << "#{filename}"
+      end
+      unfinished_files
+    end
   end
 end
-

--- a/lib/gorgon/g_logger.rb
+++ b/lib/gorgon/g_logger.rb
@@ -1,24 +1,26 @@
 require "logger"
 
-module GLogger
-  SIZE_1_MB = 1048576
+module Gorgon
+  module GLogger
+    SIZE_1_MB = 1048576
 
-  def initialize_logger log_file
-    return unless log_file
-    @logger =
-      if log_file == "-"
-        Logger.new($stdout)
-      else
-        Logger.new(log_file, 1, SIZE_1_MB)
-      end
-    @logger.datetime_format = "%Y-%m-%d %H:%M:%S "
-  end
+    def initialize_logger log_file
+      return unless log_file
+      @logger =
+        if log_file == "-"
+          Logger.new($stdout)
+        else
+          Logger.new(log_file, 1, SIZE_1_MB)
+        end
+      @logger.datetime_format = "%Y-%m-%d %H:%M:%S "
+    end
 
-  def log text
-    @logger.info(text) if @logger
-  end
+    def log text
+      @logger.info(text) if @logger
+    end
 
-  def log_error text
-    @logger.error(text) if @logger
+    def log_error text
+      @logger.error(text) if @logger
+    end
   end
 end

--- a/lib/gorgon/gem_command_handler.rb
+++ b/lib/gorgon/gem_command_handler.rb
@@ -4,44 +4,46 @@ require "yajl"
 require "gorgon_bunny/lib/gorgon_bunny"
 require 'open4'
 
-class GemCommandHandler
-  def initialize bunny
-    @bunny = bunny
-  end
+module Gorgon
+  class GemCommandHandler
+    def initialize bunny
+      @bunny = bunny
+    end
 
-  def handle payload, configuration
-    reply_exchange_name = payload[:reply_exchange_name]
-    publish_to reply_exchange_name, :type => :running_command
+    def handle payload, configuration
+      reply_exchange_name = payload[:reply_exchange_name]
+      publish_to reply_exchange_name, :type => :running_command
 
-    gem = configuration[:bin_gem_path] || "gem"
+      gem = configuration[:bin_gem_path] || "gem"
 
-    cmd = "#{gem} #{payload[:body][:gem_command]} gorgon"
-    pid, stdin, stdout, stderr = Open4::popen4 cmd
-    stdin.close
+      cmd = "#{gem} #{payload[:body][:gem_command]} gorgon"
+      pid, stdin, stdout, stderr = Open4::popen4 cmd
+      stdin.close
 
-    ignore, status = Process.waitpid2 pid
-    exitstatus = status.exitstatus
+      ignore, status = Process.waitpid2 pid
+      exitstatus = status.exitstatus
 
-    output, errors = [stdout, stderr].map { |p| begin p.read ensure p.close end }
+      output, errors = [stdout, stderr].map { |p| begin p.read ensure p.close end }
 
-    if exitstatus == 0
-      reply = {:type => :command_completed, :command => cmd, :stdout => output,
-        :stderr => errors}
-      publish_to reply_exchange_name, reply
-      @bunny.stop
-      exit     # TODO: for now exit until we implement a command to exit listeners
-    else
-      reply = {:type => :command_failed, :command => cmd, :stdout => output, :stderr => errors}
-      publish_to reply_exchange_name, reply
-   end
-  end
+      if exitstatus == 0
+        reply = {:type => :command_completed, :command => cmd, :stdout => output,
+                 :stderr => errors}
+        publish_to reply_exchange_name, reply
+        @bunny.stop
+        exit     # TODO: for now exit until we implement a command to exit listeners
+      else
+        reply = {:type => :command_failed, :command => cmd, :stdout => output, :stderr => errors}
+        publish_to reply_exchange_name, reply
+      end
+    end
 
-  private
+    private
 
-  # TODO: factors this out to a class
-  def publish_to reply_exchange_name, message
-    reply_exchange = @bunny.exchange(reply_exchange_name, :auto_delete => true
-)
-    reply_exchange.publish(Yajl::Encoder.encode(message.merge(:hostname => Socket.gethostname)))
+    # TODO: factors this out to a class
+    def publish_to reply_exchange_name, message
+      reply_exchange = @bunny.exchange(reply_exchange_name, :auto_delete => true
+                                      )
+      reply_exchange.publish(Yajl::Encoder.encode(message.merge(:hostname => Socket.gethostname)))
+    end
   end
 end

--- a/lib/gorgon/gem_service.rb
+++ b/lib/gorgon/gem_service.rb
@@ -2,76 +2,78 @@ require 'gorgon/originator_protocol'
 require 'gorgon/originator_logger'
 require 'gorgon/configuration'
 
-class GemService
-  include Configuration
+module Gorgon
+  class GemService
+    include Configuration
 
-  TIMEOUT = 3
-  def initialize
-    @configuration = load_configuration_from_file("gorgon.json")
-    @logger = OriginatorLogger.new @configuration[:originator_log_file]
-    @protocol = OriginatorProtocol.new @logger
-    @hosts_running = []
-    @started_running = 0
-    @finished_running = 0
-  end
-
-  def run command
-    EM.run do
-      @logger.log "Connecting..."
-      @protocol.connect @configuration[:connection],  :on_closed => proc {EM.stop}
-
-      @logger.log "Sending gem command #{command}..."
-      @protocol.send_message_to_listeners :gem_command, :gem_command => command
-
-      @protocol.receive_payloads do |payload|
-        @logger.log "Received #{payload}"
-
-        handle_reply(Yajl::Parser.new(:symbolize_keys => true).parse(payload))
-      end
-
-      EM.add_periodic_timer(TIMEOUT) { disconnect_if_none_running }
-   end
-  end
-
-  private
-
-  def disconnect_if_none_running
-    disconnect if @hosts_running.empty?
-  end
-
-  def handle_reply payload
-    hostname = payload[:hostname].colorize(Colors::HOST)
-    command = payload[:command].colorize(Colors::COMMAND) if payload[:command]
-
-    case payload[:type]
-    when "running_command"
-      puts "#{hostname} is running command #{payload[:command]}..."
-      @hosts_running << payload[:hostname]
-      @started_running += 1
-    when "command_completed"
-      puts "Command '#{command}' completed in #{hostname}"
-      command_finished payload
-    when "command_failed"
-      puts "Command '#{command}' failed in #{hostname}."
-      command_finished payload
-    else
-      puts "Unknown message received: #{payload}"
+    TIMEOUT = 3
+    def initialize
+      @configuration = load_configuration_from_file("gorgon.json")
+      @logger = OriginatorLogger.new @configuration[:originator_log_file]
+      @protocol = OriginatorProtocol.new @logger
+      @hosts_running = []
+      @started_running = 0
+      @finished_running = 0
     end
-  end
 
-  def command_finished payload
-    puts "Output:\n#{payload[:stdout]}#{payload[:stderr]}"
-    @hosts_running.delete payload[:hostname]
-    @finished_running += 1
-  end
+    def run command
+      EM.run do
+        @logger.log "Connecting..."
+        @protocol.connect @configuration[:connection],  :on_closed => proc {EM.stop}
 
-  def disconnect
-    @protocol.disconnect
-    print_summary
-  end
+        @logger.log "Sending gem command #{command}..."
+        @protocol.send_message_to_listeners :gem_command, :gem_command => command
 
-  def print_summary
-    puts "#{@started_running} host(s) started running the command. #{@finished_running} host(s) reported they finished"
-    puts "Use 'gorgon ping' to check if all listeners are running the correct gorgon version."
+        @protocol.receive_payloads do |payload|
+          @logger.log "Received #{payload}"
+
+          handle_reply(Yajl::Parser.new(:symbolize_keys => true).parse(payload))
+        end
+
+        EM.add_periodic_timer(TIMEOUT) { disconnect_if_none_running }
+      end
+    end
+
+    private
+
+    def disconnect_if_none_running
+      disconnect if @hosts_running.empty?
+    end
+
+    def handle_reply payload
+      hostname = payload[:hostname].colorize(Colors::HOST)
+      command = payload[:command].colorize(Colors::COMMAND) if payload[:command]
+
+      case payload[:type]
+      when "running_command"
+        puts "#{hostname} is running command #{payload[:command]}..."
+        @hosts_running << payload[:hostname]
+        @started_running += 1
+      when "command_completed"
+        puts "Command '#{command}' completed in #{hostname}"
+        command_finished payload
+      when "command_failed"
+        puts "Command '#{command}' failed in #{hostname}."
+        command_finished payload
+      else
+        puts "Unknown message received: #{payload}"
+      end
+    end
+
+    def command_finished payload
+      puts "Output:\n#{payload[:stdout]}#{payload[:stderr]}"
+      @hosts_running.delete payload[:hostname]
+      @finished_running += 1
+    end
+
+    def disconnect
+      @protocol.disconnect
+      print_summary
+    end
+
+    def print_summary
+      puts "#{@started_running} host(s) started running the command. #{@finished_running} host(s) reported they finished"
+      puts "Use 'gorgon ping' to check if all listeners are running the correct gorgon version."
+    end
   end
 end

--- a/lib/gorgon/host_state.rb
+++ b/lib/gorgon/host_state.rb
@@ -1,31 +1,33 @@
-class HostState
-  def initialize
-    @running_workers = {}
-  end
-
-  def file_started worker_id, filename
-    if @running_workers.has_key? worker_id
-      puts "WARNING: worker #{worker_id} started running a new file, but a 'finish' message has not been received for file #{@running_workers[:filename]}"
+module Gorgon
+  class HostState
+    def initialize
+      @running_workers = {}
     end
 
-    @running_workers[worker_id] = filename
-  end
+    def file_started worker_id, filename
+      if @running_workers.has_key? worker_id
+        puts "WARNING: worker #{worker_id} started running a new file, but a 'finish' message has not been received for file #{@running_workers[:filename]}"
+      end
 
-  def file_finished worker_id, filename
-    if !@running_workers.has_key? worker_id || @running_workers[:worker_id] != filename
-      puts "WARNING: worker #{worker_id} finished running a file, but a 'start' message for that file was not received. File: #{filename}"
+      @running_workers[worker_id] = filename
     end
 
-    @running_workers.delete(worker_id)
-  end
+    def file_finished worker_id, filename
+      if !@running_workers.has_key? worker_id || @running_workers[:worker_id] != filename
+        puts "WARNING: worker #{worker_id} finished running a file, but a 'start' message for that file was not received. File: #{filename}"
+      end
 
-  def total_running_workers
-    @running_workers.size
-  end
+      @running_workers.delete(worker_id)
+    end
 
-  def each_running_file
-    @running_workers.each_value do |filename|
-      yield filename
+    def total_running_workers
+      @running_workers.size
+    end
+
+    def each_running_file
+      @running_workers.each_value do |filename|
+        yield filename
+      end
     end
   end
 end

--- a/lib/gorgon/job.rb
+++ b/lib/gorgon/job.rb
@@ -1,26 +1,28 @@
-class Job
-  def initialize(listener, job_definition)
-    @workers = []
-    @definition = job_definition
-  end
+module Gorgon
+  class Job
+    def initialize(listener, job_definition)
+      @workers = []
+      @definition = job_definition
+    end
 
 
 
-  def add_worker
+    def add_worker
 
-  end
+    end
 
-  def on_worker_complete
-    @available_worker_slots += 1
-    on_current_job_complete if current_job_complete?
-  end
+    def on_worker_complete
+      @available_worker_slots += 1
+      on_current_job_complete if current_job_complete?
+    end
 
-  def setup_child_process
-    worker = ChildProcess.build("gorgon", "work", @worker_communication.name, @config_filename)
+    def setup_child_process
+      worker = ChildProcess.build("gorgon", "work", @worker_communication.name, @config_filename)
 
-    worker_output = Tempfile.new("gorgon-worker")
-    worker.io.stdout = worker_output
-    worker.io.stderr = worker_output
-    worker
+      worker_output = Tempfile.new("gorgon-worker")
+      worker.io.stdout = worker_output
+      worker.io.stderr = worker_output
+      worker
+    end
   end
 end

--- a/lib/gorgon/job_definition.rb
+++ b/lib/gorgon/job_definition.rb
@@ -1,29 +1,31 @@
 require 'yajl'
 
-class JobDefinition
-  attr_accessor :file_queue_name, :reply_exchange_name, :sync, :callbacks
+module Gorgon
+  class JobDefinition
+    attr_accessor :file_queue_name, :reply_exchange_name, :sync, :callbacks
 
-  def initialize(opts={})
-    @file_queue_name = opts[:file_queue_name]
-    @reply_exchange_name = opts[:reply_exchange_name]
-    @callbacks = opts[:callbacks]
-    @sync = opts[:sync]
-  end
+    def initialize(opts={})
+      @file_queue_name = opts[:file_queue_name]
+      @reply_exchange_name = opts[:reply_exchange_name]
+      @callbacks = opts[:callbacks]
+      @sync = opts[:sync]
+    end
 
-  def to_json
-    Yajl::Encoder.encode(to_hash)
-  end
+    def to_json
+      Yajl::Encoder.encode(to_hash)
+    end
 
-  private
+    private
 
-  #This can probably be done with introspection somehow, but this is way easier despite being very verbose
-  def to_hash
-    {
-      :type => "job_definition",
-      :file_queue_name => @file_queue_name,
-      :reply_exchange_name => @reply_exchange_name,
-      :sync => @sync,
-      :callbacks => @callbacks
-    }
+    #This can probably be done with introspection somehow, but this is way easier despite being very verbose
+    def to_hash
+      {
+        :type => "job_definition",
+        :file_queue_name => @file_queue_name,
+        :reply_exchange_name => @reply_exchange_name,
+        :sync => @sync,
+        :callbacks => @callbacks
+      }
+    end
   end
 end

--- a/lib/gorgon/job_state.rb
+++ b/lib/gorgon/job_state.rb
@@ -2,125 +2,127 @@ require 'gorgon/host_state'
 
 require 'observer'
 
-class JobState
-  include Observable
+module Gorgon
+  class JobState
+    include Observable
 
-  attr_reader :total_files, :remaining_files_count, :state, :crashed_hosts
+    attr_reader :total_files, :remaining_files_count, :state, :crashed_hosts
 
-  def initialize total_files
-    @total_files = total_files
-    @remaining_files_count = total_files
-    @failed_tests = []
-    @crashed_hosts = []
-    @hosts = {}
+    def initialize total_files
+      @total_files = total_files
+      @remaining_files_count = total_files
+      @failed_tests = []
+      @crashed_hosts = []
+      @hosts = {}
 
-    if @remaining_files_count > 0
-      @state = :starting
-    else
-      @state = :complete
-    end
-  end
-
-  def failed_files_count
-    @failed_tests.count
-  end
-
-  def finished_files_count
-    total_files - remaining_files_count
-  end
-
-  def file_started payload
-    raise_if_completed
-
-    if @state == :starting
-      @state = :running
-    end
-
-    file_started_update_host_state payload
-
-    changed
-    notify_observers payload
-  end
-
-  def file_finished payload
-    raise_if_completed
-
-    @remaining_files_count -= 1
-    @state = :complete if @remaining_files_count == 0
-
-    handle_failed_test payload if failed_test?(payload)
-
-    @hosts[payload[:hostname]].file_finished payload[:worker_id], payload[:filename]
-
-    changed
-    notify_observers payload
-  end
-
-  def gorgon_crash_message payload
-    @crashed_hosts << payload[:hostname]
-    changed
-    notify_observers payload
-  end
-
-  def cancel
-    @remaining_files_count = 0
-    @state = :cancelled
-    changed
-    notify_observers({})
-  end
-
-  def each_failed_test
-    @failed_tests.each do |test|
-      yield test
-    end
-  end
-
-  def each_running_file
-    @hosts.each do |hostname, host|
-      host.each_running_file do |filename|
-        yield hostname, filename
+      if @remaining_files_count > 0
+        @state = :starting
+      else
+        @state = :complete
       end
     end
-  end
 
-  def total_running_hosts
-    @hosts.size
-  end
-
-  def total_running_workers
-    result = 0
-    @hosts.each do |hostname, host|
-      result += host.total_running_workers
+    def failed_files_count
+      @failed_tests.count
     end
-    result
-  end
 
-  def is_job_complete?
-    @state == :complete
-  end
+    def finished_files_count
+      total_files - remaining_files_count
+    end
 
-  def is_job_cancelled?
-    @state == :cancelled
-  end
+    def file_started payload
+      raise_if_completed
 
-  private
+      if @state == :starting
+        @state = :running
+      end
 
-  def file_started_update_host_state payload
-    hostname = payload[:hostname]
-    @hosts[hostname] = HostState.new if @hosts[hostname].nil?
-    @hosts[hostname].file_started payload[:worker_id], payload[:filename]
-  end
+      file_started_update_host_state payload
 
-  def handle_failed_test payload
-    @failed_tests << payload
-  end
+      changed
+      notify_observers payload
+    end
 
-  def raise_if_completed
-    raise "JobState#file_finished called when job was already complete" if is_job_complete?
-    puts "NOTICE: JobState#file_finished called after job was cancelled" if is_job_cancelled?
-  end
+    def file_finished payload
+      raise_if_completed
 
-  def failed_test? payload
-    payload[:type] == "fail" || payload[:type] == "crash"
+      @remaining_files_count -= 1
+      @state = :complete if @remaining_files_count == 0
+
+      handle_failed_test payload if failed_test?(payload)
+
+      @hosts[payload[:hostname]].file_finished payload[:worker_id], payload[:filename]
+
+      changed
+      notify_observers payload
+    end
+
+    def gorgon_crash_message payload
+      @crashed_hosts << payload[:hostname]
+      changed
+      notify_observers payload
+    end
+
+    def cancel
+      @remaining_files_count = 0
+      @state = :cancelled
+      changed
+      notify_observers({})
+    end
+
+    def each_failed_test
+      @failed_tests.each do |test|
+        yield test
+      end
+    end
+
+    def each_running_file
+      @hosts.each do |hostname, host|
+        host.each_running_file do |filename|
+          yield hostname, filename
+        end
+      end
+    end
+
+    def total_running_hosts
+      @hosts.size
+    end
+
+    def total_running_workers
+      result = 0
+      @hosts.each do |hostname, host|
+        result += host.total_running_workers
+      end
+      result
+    end
+
+    def is_job_complete?
+      @state == :complete
+    end
+
+    def is_job_cancelled?
+      @state == :cancelled
+    end
+
+    private
+
+    def file_started_update_host_state payload
+      hostname = payload[:hostname]
+      @hosts[hostname] = HostState.new if @hosts[hostname].nil?
+      @hosts[hostname].file_started payload[:worker_id], payload[:filename]
+    end
+
+    def handle_failed_test payload
+      @failed_tests << payload
+    end
+
+    def raise_if_completed
+      raise "JobState#file_finished called when job was already complete" if is_job_complete?
+      puts "NOTICE: JobState#file_finished called after job was cancelled" if is_job_cancelled?
+    end
+
+    def failed_test? payload
+      payload[:type] == "fail" || payload[:type] == "crash"
+    end
   end
 end

--- a/lib/gorgon/listener.rb
+++ b/lib/gorgon/listener.rb
@@ -16,185 +16,187 @@ require "open4"
 require "tmpdir"
 require "socket"
 
-class Listener
-  include Configuration
-  include GLogger
-  include CrashReporter
+module Gorgon
+  class Listener
+    include Configuration
+    include GLogger
+    include CrashReporter
 
-  def initialize
-    @listener_config_filename = Dir.pwd + "/gorgon_listener.json"
-    initialize_logger configuration[:log_file]
+    def initialize
+      @listener_config_filename = Dir.pwd + "/gorgon_listener.json"
+      initialize_logger configuration[:log_file]
 
-    log "Listener #{Gorgon::VERSION} initializing"
-    connect
-    initialize_personal_job_queue
-    announce_readiness_to_originators
-  end
-
-  def listen
-    at_exit_hook
-    log "Waiting for jobs..."
-    while true
-      sleep 2 unless poll
+      log "Listener #{Gorgon::VERSION} initializing"
+      connect
+      initialize_personal_job_queue
+      announce_readiness_to_originators
     end
-  end
 
-  def connect
-    @bunny = GorgonBunny.new(connection_information)
-    @bunny.start
-  end
-
-  def initialize_personal_job_queue
-    @job_queue = @bunny.queue("job_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
-    exchange = @bunny.exchange(job_exchange_name, :type => :fanout)
-    @job_queue.bind(exchange)
-  end
-
-  def announce_readiness_to_originators
-    exchange = @bunny.exchange(originator_exchange_name, :type => :fanout)
-    data = {:listener_queue_name => @job_queue.name}
-    exchange.publish(Yajl::Encoder.encode(data))
-  end
-
-  def poll
-    message = @job_queue.pop
-    return false if message == [nil, nil, nil]
-    log "Received: #{message}"
-
-    payload = message[2]
-
-    handle_request payload
-
-    log "Waiting for more jobs..."
-    return true
-  end
-
-  def handle_request json_payload
-    payload = Yajl::Parser.new(:symbolize_keys => true).parse(json_payload)
-
-    case payload[:type]
-    when "job_definition"
-      run_job(payload)
-    when "ping"
-      respond_to_ping payload[:reply_exchange_name]
-    when "gem_command"
-      GemCommandHandler.new(@bunny).handle payload, configuration
+    def listen
+      at_exit_hook
+      log "Waiting for jobs..."
+      while true
+        sleep 2 unless poll
+      end
     end
-  end
 
-  def run_job(payload)
-    @job_definition = JobDefinition.new(payload)
-    @reply_exchange = @bunny.exchange(@job_definition.reply_exchange_name, :auto_delete => true)
+    def connect
+      @bunny = GorgonBunny.new(connection_information)
+      @bunny.start
+    end
 
-    copy_source_tree(@job_definition.sync)
+    def initialize_personal_job_queue
+      @job_queue = @bunny.queue("job_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
+      exchange = @bunny.exchange(job_exchange_name, :type => :fanout)
+      @job_queue.bind(exchange)
+    end
 
-    if !@syncer.success? || !run_after_sync
+    def announce_readiness_to_originators
+      exchange = @bunny.exchange(originator_exchange_name, :type => :fanout)
+      data = {:listener_queue_name => @job_queue.name}
+      exchange.publish(Yajl::Encoder.encode(data))
+    end
+
+    def poll
+      message = @job_queue.pop
+      return false if message == [nil, nil, nil]
+      log "Received: #{message}"
+
+      payload = message[2]
+
+      handle_request payload
+
+      log "Waiting for more jobs..."
+      return true
+    end
+
+    def handle_request json_payload
+      payload = Yajl::Parser.new(:symbolize_keys => true).parse(json_payload)
+
+      case payload[:type]
+      when "job_definition"
+        run_job(payload)
+      when "ping"
+        respond_to_ping payload[:reply_exchange_name]
+      when "gem_command"
+        GemCommandHandler.new(@bunny).handle payload, configuration
+      end
+    end
+
+    def run_job(payload)
+      @job_definition = JobDefinition.new(payload)
+      @reply_exchange = @bunny.exchange(@job_definition.reply_exchange_name, :auto_delete => true)
+
+      copy_source_tree(@job_definition.sync)
+
+      if !@syncer.success? || !run_after_sync
+        clean_up
+        return
+      end
+
+      fork_worker_manager
+
       clean_up
-      return
     end
 
-    fork_worker_manager
-
-    clean_up
-  end
-
-  def at_exit_hook
-    at_exit { log "Listener will exit!"}
-  end
-
-  private
-
-  def run_after_sync
-    log "Running after_sync callback..."
-    begin
-      callback_handler.after_sync
-    rescue Exception => e
-      log_error "Exception raised when running after_sync callback_handler. Please, check your script in #{@job_definition.callbacks[:after_sync]}:"
-      log_error e.message
-      log_error "\n" + e.backtrace.join("\n")
-
-      reply = {:type => :exception,
-        :hostname => Socket.gethostname,
-        :message => "after_sync callback failed. Please, check your script in #{@job_definition.callbacks[:after_sync]}. Message: #{e.message}",
-        :backtrace => e.backtrace.join("\n")
-      }
-      @reply_exchange.publish(Yajl::Encoder.encode(reply))
-      return false
+    def at_exit_hook
+      at_exit { log "Listener will exit!"}
     end
-    true
-  end
 
-  def callback_handler
-    @callback_handler ||= CallbackHandler.new(@job_definition.callbacks)
-  end
+    private
 
-  def copy_source_tree(sync_configuration)
-    log "Downloading source tree to temp directory..."
-    @syncer = SourceTreeSyncer.new sync_configuration
-    @syncer.sync
-    if @syncer.success?
-      log "Command '#{@syncer.sys_command}' completed successfully."
-    else
-      send_crash_message @reply_exchange, @syncer.output, @syncer.errors
-      log_error "Command '#{@syncer.sys_command}' failed!"
-      log_error "Stdout:\n#{@syncer.output}"
-      log_error "Stderr:\n#{@syncer.errors}"
+    def run_after_sync
+      log "Running after_sync callback..."
+      begin
+        callback_handler.after_sync
+      rescue Exception => e
+        log_error "Exception raised when running after_sync callback_handler. Please, check your script in #{@job_definition.callbacks[:after_sync]}:"
+        log_error e.message
+        log_error "\n" + e.backtrace.join("\n")
+
+        reply = {:type => :exception,
+                 :hostname => Socket.gethostname,
+                 :message => "after_sync callback failed. Please, check your script in #{@job_definition.callbacks[:after_sync]}. Message: #{e.message}",
+                 :backtrace => e.backtrace.join("\n")
+        }
+        @reply_exchange.publish(Yajl::Encoder.encode(reply))
+        return false
+      end
+      true
     end
-  end
 
-  def clean_up
-    @syncer.remove_temp_dir
-  end
-
-  ERROR_FOOTER_TEXT = "\n***** See #{WorkerManager::STDERR_FILE} and #{WorkerManager::STDOUT_FILE} at '#{Socket.gethostname}' for complete output *****\n"
-  def fork_worker_manager
-    log "Forking Worker Manager..."
-    ENV["GORGON_CONFIG_PATH"] = @listener_config_filename
-
-    pid, stdin = Open4::popen4 "gorgon manage_workers"
-    stdin.write(@job_definition.to_json)
-    stdin.close
-
-    _, status = Process.waitpid2 pid
-    log "Worker Manager #{pid} finished"
-
-    if status.exitstatus != 0
-      exitstatus = status.exitstatus
-      log_error "Worker Manager #{pid} crashed with exit status #{exitstatus}!"
-
-      msg = report_crash @reply_exchange, :out_file => WorkerManager::STDOUT_FILE,
-      :err_file => WorkerManager::STDERR_FILE, :footer_text => ERROR_FOOTER_TEXT
-
-      log_error "Process output:\n#{msg}"
+    def callback_handler
+      @callback_handler ||= Gorgon::CallbackHandler.new(@job_definition.callbacks)
     end
-  end
 
-  def respond_to_ping reply_exchange_name
-    reply = {:type => "ping_response", :hostname => Socket.gethostname,
-      :version => Gorgon::VERSION, :worker_slots => configuration[:worker_slots]}
-    publish_to reply_exchange_name, reply
-  end
+    def copy_source_tree(sync_configuration)
+      log "Downloading source tree to temp directory..."
+      @syncer = SourceTreeSyncer.new sync_configuration
+      @syncer.sync
+      if @syncer.success?
+        log "Command '#{@syncer.sys_command}' completed successfully."
+      else
+        send_crash_message @reply_exchange, @syncer.output, @syncer.errors
+        log_error "Command '#{@syncer.sys_command}' failed!"
+        log_error "Stdout:\n#{@syncer.output}"
+        log_error "Stderr:\n#{@syncer.errors}"
+      end
+    end
 
-  def publish_to reply_exchange_name, message
-    reply_exchange = @bunny.exchange(reply_exchange_name, :auto_delete => true)
+    def clean_up
+      @syncer.remove_temp_dir
+    end
 
-    log "Sending #{message}"
-    reply_exchange.publish(Yajl::Encoder.encode(message))
-  end
+    ERROR_FOOTER_TEXT = "\n***** See #{WorkerManager::STDERR_FILE} and #{WorkerManager::STDOUT_FILE} at '#{Socket.gethostname}' for complete output *****\n"
+    def fork_worker_manager
+      log "Forking Worker Manager..."
+      ENV["GORGON_CONFIG_PATH"] = @listener_config_filename
 
-  def job_exchange_name
-    OriginatorProtocol.job_exchange_name(configuration.fetch(:cluster_id, nil))
-  end
+      pid, stdin = Open4::popen4 "gorgon manage_workers"
+      stdin.write(@job_definition.to_json)
+      stdin.close
 
-  def originator_exchange_name
-    OriginatorProtocol.originator_exchange_name(configuration.fetch(:cluster_id, nil))
-  end
+      _, status = Process.waitpid2 pid
+      log "Worker Manager #{pid} finished"
 
-  def connection_information
-    configuration[:connection]
-  end
+      if status.exitstatus != 0
+        exitstatus = status.exitstatus
+        log_error "Worker Manager #{pid} crashed with exit status #{exitstatus}!"
 
-  def configuration
-    @configuration ||= load_configuration_from_file("gorgon_listener.json")
+        msg = report_crash @reply_exchange, :out_file => WorkerManager::STDOUT_FILE,
+          :err_file => WorkerManager::STDERR_FILE, :footer_text => ERROR_FOOTER_TEXT
+
+        log_error "Process output:\n#{msg}"
+      end
+    end
+
+    def respond_to_ping reply_exchange_name
+      reply = {:type => "ping_response", :hostname => Socket.gethostname,
+               :version => Gorgon::VERSION, :worker_slots => configuration[:worker_slots]}
+      publish_to reply_exchange_name, reply
+    end
+
+    def publish_to reply_exchange_name, message
+      reply_exchange = @bunny.exchange(reply_exchange_name, :auto_delete => true)
+
+      log "Sending #{message}"
+      reply_exchange.publish(Yajl::Encoder.encode(message))
+    end
+
+    def job_exchange_name
+      OriginatorProtocol.job_exchange_name(configuration.fetch(:cluster_id, nil))
+    end
+
+    def originator_exchange_name
+      OriginatorProtocol.originator_exchange_name(configuration.fetch(:cluster_id, nil))
+    end
+
+    def connection_information
+      configuration[:connection]
+    end
+
+    def configuration
+      @configuration ||= load_configuration_from_file("gorgon_listener.json")
+    end
   end
 end

--- a/lib/gorgon/listener_installer.rb
+++ b/lib/gorgon/listener_installer.rb
@@ -1,122 +1,123 @@
 require 'etc'
 require 'fileutils'
 
-class ListenerInstaller
-  include Configuration
+module Gorgon
+  class ListenerInstaller
+    include Configuration
 
-  GORGON_DIR=".gorgon"
-  DEFAULT_NO_WORKERS = 4
-  LISTENER_CONFIG_FILE = "gorgon_listener.json"
-  GORGON_INIT_FILE = "/etc/init/gorgon.conf"
+    GORGON_DIR=".gorgon"
+    DEFAULT_NO_WORKERS = 4
+    LISTENER_CONFIG_FILE = "gorgon_listener.json"
+    GORGON_INIT_FILE = "/etc/init/gorgon.conf"
 
-  def self.install
-    ListenerInstaller.new.install
-  end
-
-  def install
-    @configuration = load_configuration_from_file("gorgon.json")
-
-    FileUtils.mkdir_p gorgon_dir_path
-    Dir.chdir gorgon_dir_path
-
-    create_listener_config_file
-
-    create_gorgon_service
-
-    start_gorgon_daemon
-  end
-
-  private
-
-  def gorgon_dir_path
-    @gorgon_dir_path ||= "#{Dir.home}/#{GORGON_DIR}"
-  end
-
-  def create_listener_config_file
-    worker_slots = worker_slots_prompt
-    puts "Using #{worker_slots} worker slots"
-    amqp_host = @configuration[:connection][:host]
-    puts "Amqp host is '#{amqp_host}'"
-
-    puts "Creating #{LISTENER_CONFIG_FILE} in #{Dir.pwd}"
-    File.open(LISTENER_CONFIG_FILE, 'w') do |f|
-      f.write listener_config(amqp_host, worker_slots)
-    end
-  end
-
-  def create_gorgon_service
-    params = {}
-    params[:username] = Etc.getlogin
-    params[:rvm_bin_path] = rvm_bin_path
-    params[:gemset] = get_current_gemset
-
-    tmp_gorgon_conf = '/tmp/gorgon.conf'
-    File.open(tmp_gorgon_conf, 'w') do |f|
-      f.write gorgon_conf(params)
+    def self.install
+      ListenerInstaller.new.install
     end
 
-    puts "Creating '#{GORGON_INIT_FILE}'"
+    def install
+      @configuration = load_configuration_from_file("gorgon.json")
 
-    system("sudo cp /tmp/gorgon.conf #{GORGON_INIT_FILE}")
-  end
+      FileUtils.mkdir_p gorgon_dir_path
+      Dir.chdir gorgon_dir_path
 
-  def rvm_bin_path
-    cmd = 'which rvm'
-    path = get_shell_cmd_output cmd, "Error getting rvm path. Make sure '#{cmd}' works"
-    puts "Using '#{path}'"
-    path
-  end
+      create_listener_config_file
 
-  def get_current_gemset
-    return @gemset unless @gemset.nil?
+      create_gorgon_service
 
-    cmd = 'rvm current'
-    @gemset = get_shell_cmd_output cmd, "Error getting current gem. Make sure '#{cmd}' works"
-    puts "Using gemset '#{@gemset}'."
-    @gemset
-  end
-
-  def get_shell_cmd_output cmd, error_message
-    result = `#{cmd}`.strip
-    if $?.exitstatus != 0
-      $stderr.puts "#{error_message}"
-      $stderr.puts "Aborting installation"
-      exit
+      start_gorgon_daemon
     end
-    result
-  end
 
-  def start_gorgon_daemon
-    system("sudo start gorgon")
-  end
+    private
 
-  def gem_available?(name)
-    Gem::Specification.find_by_name(name)
-  rescue Gem::LoadError
-    false
-  rescue
-    Gem.available?(name)
-  end
+    def gorgon_dir_path
+      @gorgon_dir_path ||= "#{Dir.home}/#{GORGON_DIR}"
+    end
 
-  def worker_slots_prompt
-    begin
-      puts "Number of worker slots (default #{DEFAULT_NO_WORKERS})?"
-      input = $stdin.gets.chomp
-      if input == ""
-        worker_slots = DEFAULT_NO_WORKERS
-        break
+    def create_listener_config_file
+      worker_slots = worker_slots_prompt
+      puts "Using #{worker_slots} worker slots"
+      amqp_host = @configuration[:connection][:host]
+      puts "Amqp host is '#{amqp_host}'"
+
+      puts "Creating #{LISTENER_CONFIG_FILE} in #{Dir.pwd}"
+      File.open(LISTENER_CONFIG_FILE, 'w') do |f|
+        f.write listener_config(amqp_host, worker_slots)
+      end
+    end
+
+    def create_gorgon_service
+      params = {}
+      params[:username] = Etc.getlogin
+      params[:rvm_bin_path] = rvm_bin_path
+      params[:gemset] = get_current_gemset
+
+      tmp_gorgon_conf = '/tmp/gorgon.conf'
+      File.open(tmp_gorgon_conf, 'w') do |f|
+        f.write gorgon_conf(params)
       end
 
-      worker_slots = input.to_i
-      if worker_slots <= 0 || worker_slots >= 20
-        puts "Please, enter a valid number between 0 and 19"
-      end
-    end while worker_slots <= 0 || worker_slots >= 20
-    worker_slots
-  end
+      puts "Creating '#{GORGON_INIT_FILE}'"
 
-  def listener_config amqp_host, worker_slots
-    <<-CONFIG
+      system("sudo cp /tmp/gorgon.conf #{GORGON_INIT_FILE}")
+    end
+
+    def rvm_bin_path
+      cmd = 'which rvm'
+      path = get_shell_cmd_output cmd, "Error getting rvm path. Make sure '#{cmd}' works"
+      puts "Using '#{path}'"
+      path
+    end
+
+    def get_current_gemset
+      return @gemset unless @gemset.nil?
+
+      cmd = 'rvm current'
+      @gemset = get_shell_cmd_output cmd, "Error getting current gem. Make sure '#{cmd}' works"
+      puts "Using gemset '#{@gemset}'."
+      @gemset
+    end
+
+    def get_shell_cmd_output cmd, error_message
+      result = `#{cmd}`.strip
+      if $?.exitstatus != 0
+        $stderr.puts "#{error_message}"
+        $stderr.puts "Aborting installation"
+        exit
+      end
+      result
+    end
+
+    def start_gorgon_daemon
+      system("sudo start gorgon")
+    end
+
+    def gem_available?(name)
+      Gem::Specification.find_by_name(name)
+    rescue Gem::LoadError
+      false
+    rescue
+      Gem.available?(name)
+    end
+
+    def worker_slots_prompt
+      begin
+        puts "Number of worker slots (default #{DEFAULT_NO_WORKERS})?"
+        input = $stdin.gets.chomp
+        if input == ""
+          worker_slots = DEFAULT_NO_WORKERS
+          break
+        end
+
+        worker_slots = input.to_i
+        if worker_slots <= 0 || worker_slots >= 20
+          puts "Please, enter a valid number between 0 and 19"
+        end
+      end while worker_slots <= 0 || worker_slots >= 20
+      worker_slots
+    end
+
+    def listener_config amqp_host, worker_slots
+      <<-CONFIG
 {
   "connection": {
     "host": "#{amqp_host}"
@@ -125,11 +126,11 @@ class ListenerInstaller
   "worker_slots": #{worker_slots},
   "log_file": "/tmp/gorgon-remote.log"
 }
-CONFIG
-  end
+      CONFIG
+    end
 
-  def gorgon_conf params
-    <<-CONF_FILE
+    def gorgon_conf params
+      <<-CONF_FILE
 description "Start gorgon listener"
 
 start on filesystem or runlevel [2345]
@@ -148,6 +149,7 @@ EOF
 end script
 
 exec su - #{params[:username]} -c 'cd #{gorgon_dir_path} && #{params[:rvm_bin_path]} #{params[:gemset]} do gorgon listen >> /var/log/gorgon/gorgon.log 2>&1'
-CONF_FILE
+      CONF_FILE
+    end
   end
 end

--- a/lib/gorgon/originator.rb
+++ b/lib/gorgon/originator.rb
@@ -15,218 +15,220 @@ require 'awesome_print'
 require 'etc'
 require 'socket'
 
-class Originator
-  include Configuration
+module Gorgon
+  class Originator
+    include Configuration
 
-  SPEC_SUCCESS_EXIT_STATUS = 0
-  SPEC_FAILURE_EXIT_STATUS = 1
-  SYNC_ERROR_EXIT_STATUS = 2
-  ERROR_EXIT_STATUS = 3
+    SPEC_SUCCESS_EXIT_STATUS = 0
+    SPEC_FAILURE_EXIT_STATUS = 1
+    SYNC_ERROR_EXIT_STATUS = 2
+    ERROR_EXIT_STATUS = 3
 
 
-  def initialize
-    @configuration = nil
-  end
+    def initialize
+      @configuration = nil
+    end
 
-  def originate
-    begin
-      Signal.trap("INT") { ctrl_c }
-      Signal.trap("TERM") { ctrl_c }
+    def originate
+      begin
+        Signal.trap("INT") { ctrl_c }
+        Signal.trap("TERM") { ctrl_c }
 
-      exit_status = publish
-      @logger.log "Originator finished successfully"
-      exit_status
-    rescue StandardError
-      $stderr.puts "Unhandled exception in originator:"
-      $stderr.puts $!.message
-      $stderr.puts $!.backtrace.join("\n")
-      $stderr.puts "----------------------------------"
-      $stderr.puts "Now attempting to cancel the job."
-      @logger.log_error "Unhandled Exception!" if @logger
+        exit_status = publish
+        @logger.log "Originator finished successfully"
+        exit_status
+      rescue StandardError
+        $stderr.puts "Unhandled exception in originator:"
+        $stderr.puts $!.message
+        $stderr.puts $!.backtrace.join("\n")
+        $stderr.puts "----------------------------------"
+        $stderr.puts "Now attempting to cancel the job."
+        @logger.log_error "Unhandled Exception!" if @logger
+        cancel_job
+        exit ERROR_EXIT_STATUS
+      end
+    end
+
+    def cancel_job
+      ShutdownManager.new(protocol: @protocol, job_state: @job_state).cancel_job
+    end
+
+    def ctrl_c
+      puts "\nCtrl-C received! Just wait a moment while I clean up..."
       cancel_job
-      exit ERROR_EXIT_STATUS
-    end
-  end
-
-  def cancel_job
-    ShutdownManager.new(protocol: @protocol, job_state: @job_state).cancel_job
-  end
-
-  def ctrl_c
-    puts "\nCtrl-C received! Just wait a moment while I clean up..."
-    cancel_job
-  end
-
-  def publish
-    exit_status = SPEC_SUCCESS_EXIT_STATUS
-
-    @logger = OriginatorLogger.new configuration[:originator_log_file]
-
-    if files.empty?
-      $stderr.puts "There are no files to test! Quitting."
-      exit ERROR_EXIT_STATUS
     end
 
-    cluster_id = callback_handler.before_originate
+    def publish
+      exit_status = SPEC_SUCCESS_EXIT_STATUS
 
-    push_source_code
+      @logger = OriginatorLogger.new configuration[:originator_log_file]
 
-    @protocol = OriginatorProtocol.new(@logger, cluster_id)
-
-    EventMachine.run do
-      publish_files_and_job
-
-      @protocol.receive_payloads do |payload|
-        exit_status |= handle_reply(payload)
+      if files.empty?
+        $stderr.puts "There are no files to test! Quitting."
+        exit ERROR_EXIT_STATUS
       end
 
-      @protocol.receive_new_listener_notifications do |payload|
-        handle_new_listener_notification(payload)
+      cluster_id = callback_handler.before_originate
+
+      push_source_code
+
+      @protocol = OriginatorProtocol.new(@logger, cluster_id)
+
+      EventMachine.run do
+        publish_files_and_job
+
+        @protocol.receive_payloads do |payload|
+          exit_status |= handle_reply(payload)
+        end
+
+        @protocol.receive_new_listener_notifications do |payload|
+          handle_new_listener_notification(payload)
+        end
+      end
+
+      callback_handler.after_job_finishes
+      exit_status
+    end
+
+    def publish_files_and_job
+      @logger.log "Connecting..."
+      @protocol.connect connection_information, :on_closed => method(:on_disconnect)
+
+      @logger.log "Publishing files..."
+      @protocol.publish_files files
+      create_job_state_and_observers
+
+      @logger.log "Publishing Job..."
+      @protocol.publish_job_to_all job_definition
+      @logger.log "Job Published"
+    end
+
+    def callback_handler
+      @callback_handler ||= CallbackHandler.new(configuration[:job][:callbacks])
+    end
+
+    def push_source_code
+      syncer = SourceTreeSyncer.new(sync_configuration)
+      syncer.push
+      if syncer.success?
+        @logger.log "Command '#{syncer.sys_command}' completed successfully."
+      else
+        $stderr.puts "Command '#{syncer.sys_command}' failed!"
+        $stderr.puts "Stdout:\n#{syncer.output}"
+        $stderr.puts "Stderr:\n#{syncer.errors}"
+        exit SYNC_ERROR_EXIT_STATUS
       end
     end
 
-    callback_handler.after_job_finishes
-    exit_status
-  end
-
-  def publish_files_and_job
-    @logger.log "Connecting..."
-    @protocol.connect connection_information, :on_closed => method(:on_disconnect)
-
-    @logger.log "Publishing files..."
-    @protocol.publish_files files
-    create_job_state_and_observers
-
-    @logger.log "Publishing Job..."
-    @protocol.publish_job_to_all job_definition
-    @logger.log "Job Published"
-  end
-
-  def callback_handler
-    @callback_handler ||= CallbackHandler.new(configuration[:job][:callbacks])
-  end
-
-  def push_source_code
-    syncer = SourceTreeSyncer.new(sync_configuration)
-    syncer.push
-    if syncer.success?
-      @logger.log "Command '#{syncer.sys_command}' completed successfully."
-    else
-      $stderr.puts "Command '#{syncer.sys_command}' failed!"
-      $stderr.puts "Stdout:\n#{syncer.output}"
-      $stderr.puts "Stderr:\n#{syncer.errors}"
-      exit SYNC_ERROR_EXIT_STATUS
-    end
-  end
-
-  def cleanup_if_job_complete
-    if @job_state.is_job_complete?
-      @logger.log "Job is done"
-      @protocol.disconnect
-    end
-  end
-
-  def handle_reply(payload)
-    payload = Yajl::Parser.new(:symbolize_keys => true).parse(payload)
-
-    # at some point this will probably need to be fancy polymorphic type based responses, or at least a nice switch statement
-    if payload[:action] == "finish"
-      @job_state.file_finished payload
-    elsif payload[:action] == "start"
-      @job_state.file_started payload
-    elsif payload[:type] == "crash"
-      @job_state.gorgon_crash_message payload
-    elsif payload[:type] == "exception"
-      # TODO
-      ap payload
-    else
-      ap payload
+    def cleanup_if_job_complete
+      if @job_state.is_job_complete?
+        @logger.log "Job is done"
+        @protocol.disconnect
+      end
     end
 
-    @logger.log_message payload
-    # Uncomment this to see each message received by originator
-    # ap payload
+    def handle_reply(payload)
+      payload = Yajl::Parser.new(:symbolize_keys => true).parse(payload)
 
-    cleanup_if_job_complete
-    exit_status(payload)
-  end
+      # at some point this will probably need to be fancy polymorphic type based responses, or at least a nice switch statement
+      if payload[:action] == "finish"
+        @job_state.file_finished payload
+      elsif payload[:action] == "start"
+        @job_state.file_started payload
+      elsif payload[:type] == "crash"
+        @job_state.gorgon_crash_message payload
+      elsif payload[:type] == "exception"
+        # TODO
+        ap payload
+      else
+        ap payload
+      end
 
-  def handle_new_listener_notification(payload)
-    payload = Yajl::Parser.new(:symbolize_keys => true).parse(payload)
+      @logger.log_message payload
+      # Uncomment this to see each message received by originator
+      # ap payload
 
-    if payload[:listener_queue_name]
-      @protocol.publish_job_to_one(job_definition, payload[:listener_queue_name])
-    else
-      puts "Received unexpected payload on originator queue"
-      ap payload
+      cleanup_if_job_complete
+      exit_status(payload)
     end
-  end
 
-  def create_job_state_and_observers
-    @job_state = JobState.new files.count
-    RuntimeRecorder.new @job_state, configuration[:runtime_file]
-    @progress_bar_view = ProgressBarView.new @job_state
-    @progress_bar_view.show
-    FailuresPrinter.new(configuration, @job_state)
-  end
+    def handle_new_listener_notification(payload)
+      payload = Yajl::Parser.new(:symbolize_keys => true).parse(payload)
 
-  def on_disconnect
-    EventMachine.stop
-  end
-
-  def connection_information
-    configuration[:connection]
-  end
-
-  def files
-    @files ||= RuntimeFileReader.new(configuration).sorted_files
-  end
-
-  def job_definition
-    # TODO: remove duplication. Use sync_configuration
-    job_config = configuration[:job]
-    job_config[:sync] = {} unless job_config.has_key?(:sync)
-    job_config[:sync][:source_tree_path] = source_tree_path(job_config[:sync])
-    JobDefinition.new(configuration[:job])
-  end
-
-  private
-
-  def exit_status(payload)
-    return SPEC_FAILURE_EXIT_STATUS if ["crash", "exception", "fail"].include?(payload[:type])
-    SPEC_SUCCESS_EXIT_STATUS
-  end
-
-  def sync_configuration
-    configuration[:job].
-      fetch(:sync, {}).
-      merge(source_tree_path: source_tree_path(configuration[:job][:sync])
-    )
-  end
-
-  def source_tree_path(sync_config)
-    hostname = Socket.gethostname
-    source_code_root = File.basename(Dir.pwd)
-
-    if sync_config && sync_config[:rsync_transport] == SourceTreeSyncer::RSYNC_TRANSPORT_SSH
-      "#{file_server_host}:#{hostname}_#{source_code_root}"
-    else
-      "rsync://#{file_server_host}:43434/src/#{hostname}_#{source_code_root}"
+      if payload[:listener_queue_name]
+        @protocol.publish_job_to_one(job_definition, payload[:listener_queue_name])
+      else
+        puts "Received unexpected payload on originator queue"
+        ap payload
+      end
     end
-  end
 
-  def file_server_host
-    if configuration[:file_server].nil?
-      raise <<-MSG
+    def create_job_state_and_observers
+      @job_state = JobState.new files.count
+      RuntimeRecorder.new @job_state, configuration[:runtime_file]
+      @progress_bar_view = ProgressBarView.new @job_state
+      @progress_bar_view.show
+      FailuresPrinter.new(configuration, @job_state)
+    end
+
+    def on_disconnect
+      EventMachine.stop
+    end
+
+    def connection_information
+      configuration[:connection]
+    end
+
+    def files
+      @files ||= RuntimeFileReader.new(configuration).sorted_files
+    end
+
+    def job_definition
+      # TODO: remove duplication. Use sync_configuration
+      job_config = configuration[:job]
+      job_config[:sync] = {} unless job_config.has_key?(:sync)
+      job_config[:sync][:source_tree_path] = source_tree_path(job_config[:sync])
+      JobDefinition.new(configuration[:job])
+    end
+
+    private
+
+    def exit_status(payload)
+      return SPEC_FAILURE_EXIT_STATUS if ["crash", "exception", "fail"].include?(payload[:type])
+      SPEC_SUCCESS_EXIT_STATUS
+    end
+
+    def sync_configuration
+      configuration[:job].
+        fetch(:sync, {}).
+        merge(source_tree_path: source_tree_path(configuration[:job][:sync])
+             )
+    end
+
+    def source_tree_path(sync_config)
+      hostname = Socket.gethostname
+      source_code_root = File.basename(Dir.pwd)
+
+      if sync_config && sync_config[:rsync_transport] == SourceTreeSyncer::RSYNC_TRANSPORT_SSH
+        "#{file_server_host}:#{hostname}_#{source_code_root}"
+      else
+        "rsync://#{file_server_host}:43434/src/#{hostname}_#{source_code_root}"
+      end
+    end
+
+    def file_server_host
+      if configuration[:file_server].nil?
+        raise <<-MSG
         Missing file_server configuration.
         See https://github.com/Fitzsimmons/Gorgon/blob/master/gorgon.json.sample for a sample configuration
-MSG
+        MSG
+      end
+
+      configuration[:file_server][:host]
     end
 
-    configuration[:file_server][:host]
-  end
-
-  def configuration
-    @configuration ||= load_configuration_from_file("gorgon.json")
+    def configuration
+      @configuration ||= load_configuration_from_file("gorgon.json")
+    end
   end
 end

--- a/lib/gorgon/originator_logger.rb
+++ b/lib/gorgon/originator_logger.rb
@@ -1,39 +1,41 @@
 require 'gorgon/g_logger'
 
-class OriginatorLogger
-  include GLogger
+module Gorgon
+  class OriginatorLogger
+    include GLogger
 
-  def initialize log_file
-    initialize_logger log_file
-  end
-
-  def log_message(payload)
-    if payload[:action] == "start"
-      log("Started running '#{payload[:filename]}' at '#{payload[:hostname]}:#{payload[:worker_id]}'")
-    elsif payload[:action] == "finish"
-      print_finish(payload)
-    elsif payload[:type] == "crash" || payload[:type] == "exception"
-      # TODO: improve logging of these messages
-      log(payload)
-    else # to be removed
-      ap payload
+    def initialize log_file
+      initialize_logger log_file
     end
-  end
 
-  private
-
-  def print_finish(payload)
-    msg = "Finished running '#{payload[:filename]}' at '#{payload[:hostname]}:#{payload[:worker_id]}'"
-    msg << failure_message(payload[:failures]) if payload[:type] == "fail"
-    log msg
-  end
-
-  def failure_message(failures)
-    msg = []
-    failures.each do |failure|
-      msg << failure
+    def log_message(payload)
+      if payload[:action] == "start"
+        log("Started running '#{payload[:filename]}' at '#{payload[:hostname]}:#{payload[:worker_id]}'")
+      elsif payload[:action] == "finish"
+        print_finish(payload)
+      elsif payload[:type] == "crash" || payload[:type] == "exception"
+        # TODO: improve logging of these messages
+        log(payload)
+      else # to be removed
+        ap payload
+      end
     end
-    msg << ''
-    msg.join("\n")
+
+    private
+
+    def print_finish(payload)
+      msg = "Finished running '#{payload[:filename]}' at '#{payload[:hostname]}:#{payload[:worker_id]}'"
+      msg << failure_message(payload[:failures]) if payload[:type] == "fail"
+      log msg
+    end
+
+    def failure_message(failures)
+      msg = []
+      failures.each do |failure|
+        msg << failure
+      end
+      msg << ''
+      msg.join("\n")
+    end
   end
 end

--- a/lib/gorgon/originator_protocol.rb
+++ b/lib/gorgon/originator_protocol.rb
@@ -4,113 +4,115 @@ require 'gorgon/job_definition'
 require 'amqp'
 require 'uuidtools'
 
-class OriginatorProtocol
-  def initialize(logger, cluster_id=nil)
-    @originator_exchange_name = OriginatorProtocol.originator_exchange_name(cluster_id)
-    @job_exchange_name = OriginatorProtocol.job_exchange_name(cluster_id)
-    @logger = logger
-  end
-
-  def self.originator_exchange_name(cluster_id)
-    if cluster_id
-      "gorgon.originators.#{cluster_id}"
-    else
-      "gorgon.originators"
+module Gorgon
+  class OriginatorProtocol
+    def initialize(logger, cluster_id=nil)
+      @originator_exchange_name = OriginatorProtocol.originator_exchange_name(cluster_id)
+      @job_exchange_name = OriginatorProtocol.job_exchange_name(cluster_id)
+      @logger = logger
     end
-  end
 
-  def self.job_exchange_name(cluster_id)
-    if cluster_id
-      "gorgon.jobs.#{cluster_id}"
-    else
-      'gorgon.jobs'
+    def self.originator_exchange_name(cluster_id)
+      if cluster_id
+        "gorgon.originators.#{cluster_id}"
+      else
+        "gorgon.originators"
+      end
     end
-  end
 
-  def connect connection_information, options={}
-    @connection = AMQP.connect(connection_information)
-    @channel = AMQP::Channel.new(@connection)
-    @connection.on_closed { options[:on_closed].call } if options[:on_closed]
-    open_queues
-  end
-
-  def publish_files files
-    @file_queue = @channel.queue("file_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
-
-    files.each do |file|
-      @channel.default_exchange.publish(file, :routing_key => @file_queue.name)
+    def self.job_exchange_name(cluster_id)
+      if cluster_id
+        "gorgon.jobs.#{cluster_id}"
+      else
+        'gorgon.jobs'
+      end
     end
-  end
 
-  def publish_job_to_all job_definition
-    job_definition = append_protocol_information_to_job_definition(job_definition)
-    @channel.fanout(@job_exchange_name).publish(job_definition.to_json)
-  end
-
-  def publish_job_to_one job_definition, listener_queue_name
-    job_definition = append_protocol_information_to_job_definition(job_definition)
-    @channel.default_exchange.publish(job_definition.to_json, :routing_key => listener_queue_name)
-  end
-
-  def append_protocol_information_to_job_definition job_definition
-    job_definition = job_definition.dup
-
-    job_definition.file_queue_name = @file_queue.name
-    job_definition.reply_exchange_name = @reply_exchange.name
-
-    return job_definition
-  end
-
-  def send_message_to_listeners type, body={}
-    # TODO: we probably want to use a different exchange for this type of messages
-    message = {:type => type, :reply_exchange_name => @reply_exchange.name, :body => body}
-    @channel.fanout(@job_exchange_name).publish(Yajl::Encoder.encode(message))
-  end
-
-  def receive_payloads
-    @reply_queue.subscribe do |payload|
-      yield payload
+    def connect connection_information, options={}
+      @connection = AMQP.connect(connection_information)
+      @channel = AMQP::Channel.new(@connection)
+      @connection.on_closed { options[:on_closed].call } if options[:on_closed]
+      open_queues
     end
-  end
 
-  def receive_new_listener_notifications
-    @originator_queue.subscribe do |payload|
-      yield payload
+    def publish_files files
+      @file_queue = @channel.queue("file_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
+
+      files.each do |file|
+        @channel.default_exchange.publish(file, :routing_key => @file_queue.name)
+      end
     end
-  end
 
-  def cancel_job
-    @file_queue.purge if @file_queue
-    @channel.fanout("gorgon.worker_managers").publish(cancel_message) if @channel
-    @logger.log "Cancel Message sent"
-  end
+    def publish_job_to_all job_definition
+      job_definition = append_protocol_information_to_job_definition(job_definition)
+      @channel.fanout(@job_exchange_name).publish(job_definition.to_json)
+    end
 
-  def disconnect
-    cleanup_queues_and_exchange
-    @connection.disconnect if @connection
-  end
+    def publish_job_to_one job_definition, listener_queue_name
+      job_definition = append_protocol_information_to_job_definition(job_definition)
+      @channel.default_exchange.publish(job_definition.to_json, :routing_key => listener_queue_name)
+    end
 
-  private
+    def append_protocol_information_to_job_definition job_definition
+      job_definition = job_definition.dup
 
-  def open_queues
-    @reply_queue = @channel.queue("reply_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
-    @reply_exchange = @channel.direct("reply_exchange_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
-    @reply_queue.bind(@reply_exchange)
+      job_definition.file_queue_name = @file_queue.name
+      job_definition.reply_exchange_name = @reply_exchange.name
 
-    # Provides a way for new listeners to announce their presence to originators that have already started the job
-    @originator_queue = @channel.queue("originator_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
-    @originator_exchange = @channel.fanout(@originator_exchange_name)
-    @originator_queue.bind(@originator_exchange)
-  end
+      return job_definition
+    end
 
-  def cleanup_queues_and_exchange
-    @reply_queue.delete if @reply_queue
-    @file_queue.delete if @file_queue
-    @reply_exchange.delete if @reply_exchange
-    @originator_queue.delete if @originator_queue
-  end
+    def send_message_to_listeners type, body={}
+      # TODO: we probably want to use a different exchange for this type of messages
+      message = {:type => type, :reply_exchange_name => @reply_exchange.name, :body => body}
+      @channel.fanout(@job_exchange_name).publish(Yajl::Encoder.encode(message))
+    end
 
-  def cancel_message
-    Yajl::Encoder.encode({:action => "cancel_job"})
+    def receive_payloads
+      @reply_queue.subscribe do |payload|
+        yield payload
+      end
+    end
+
+    def receive_new_listener_notifications
+      @originator_queue.subscribe do |payload|
+        yield payload
+      end
+    end
+
+    def cancel_job
+      @file_queue.purge if @file_queue
+      @channel.fanout("gorgon.worker_managers").publish(cancel_message) if @channel
+      @logger.log "Cancel Message sent"
+    end
+
+    def disconnect
+      cleanup_queues_and_exchange
+      @connection.disconnect if @connection
+    end
+
+    private
+
+    def open_queues
+      @reply_queue = @channel.queue("reply_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
+      @reply_exchange = @channel.direct("reply_exchange_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
+      @reply_queue.bind(@reply_exchange)
+
+      # Provides a way for new listeners to announce their presence to originators that have already started the job
+      @originator_queue = @channel.queue("originator_queue_" + UUIDTools::UUID.timestamp_create.to_s, :auto_delete => true)
+      @originator_exchange = @channel.fanout(@originator_exchange_name)
+      @originator_queue.bind(@originator_exchange)
+    end
+
+    def cleanup_queues_and_exchange
+      @reply_queue.delete if @reply_queue
+      @file_queue.delete if @file_queue
+      @reply_exchange.delete if @reply_exchange
+      @originator_queue.delete if @originator_queue
+    end
+
+    def cancel_message
+      Yajl::Encoder.encode({:action => "cancel_job"})
+    end
   end
 end

--- a/lib/gorgon/pipe_forker.rb
+++ b/lib/gorgon/pipe_forker.rb
@@ -1,22 +1,24 @@
-module PipeForker
-  def pipe_fork
-    stdin = Pipe.new(*IO.pipe)
-    pid = fork do
-      stdin.write.close
-      STDIN.reopen(stdin.read)
+module Gorgon
+  module PipeForker
+    def pipe_fork
+      stdin = Pipe.new(*IO.pipe)
+      pid = fork do
+        stdin.write.close
+        STDIN.reopen(stdin.read)
+        stdin.read.close
+
+        yield
+
+        exit
+      end
+
       stdin.read.close
 
-      yield
-
-      exit
+      return pid, stdin.write
     end
 
-    stdin.read.close
+    private
 
-    return pid, stdin.write
+    Pipe = Struct.new(:read, :write)
   end
-
-  private
-
-  Pipe = Struct.new(:read, :write)
 end

--- a/lib/gorgon/progress_bar_view.rb
+++ b/lib/gorgon/progress_bar_view.rb
@@ -2,142 +2,144 @@ require 'gorgon/colors'
 
 require 'ruby-progressbar'
 require 'colorize'
+module Gorgon
+  class ProgressBarView
 
-MAX_LENGTH = 200
-LOADING_MSG = "Loading environment and workers..."
-RUNNING_MSG = "Running files:"
-LEGEND_MSG = "Legend:\nF - failure files count\nH - number of hosts that have run files\nW - number of workers running files"
+    MAX_LENGTH = 200
+    LOADING_MSG = "Loading environment and workers..."
+    RUNNING_MSG = "Running files:"
+    LEGEND_MSG = "Legend:\nF - failure files count\nH - number of hosts that have run files\nW - number of workers running files"
 
-PROGRESS_BAR_REFRESH_RATE = 0.5
-# - because the resolution of the elapsed time is one second, we use the nyquist frequency of 0.5 seconds
-# http://en.wikipedia.org/wiki/Nyquist_frequency
+    PROGRESS_BAR_REFRESH_RATE = 0.5
+    # - because the resolution of the elapsed time is one second, we use the nyquist frequency of 0.5 seconds
+    # http://en.wikipedia.org/wiki/Nyquist_frequency
 
-class ProgressBarView
-  def initialize job_state
-    @job_state = job_state
-    @job_state.add_observer(self)
-    @timer = EventMachine::PeriodicTimer.new(PROGRESS_BAR_REFRESH_RATE) { update_elapsed_time }
-  end
-
-  def show
-    print LOADING_MSG
-  end
-
-  def update payload={}
-    output_gorgon_crash_message payload if gorgon_crashed? payload
-
-    create_progress_bar_if_started_job_running
-
-    return if @progress_bar.nil? || @finished
-
-    failed_files_count = @job_state.failed_files_count
-
-    @progress_bar.title=" F: #{failed_files_count} H: #{@job_state.total_running_hosts} W: #{@job_state.total_running_workers}"
-    if failed_files_count > 0
-      @progress_bar.format(format(bar: :red, title: :default))
+    def initialize job_state
+      @job_state = job_state
+      @job_state.add_observer(self)
+      @timer = EventMachine::PeriodicTimer.new(PROGRESS_BAR_REFRESH_RATE) { update_elapsed_time }
     end
 
-    @progress_bar.progress = @job_state.finished_files_count
-
-    if @job_state.is_job_complete? || @job_state.is_job_cancelled?
-      @finished = true
-      print_summary
+    def show
+      print LOADING_MSG
     end
-  end
 
-  def create_progress_bar_if_started_job_running
-    if @progress_bar.nil? && @job_state.state == :running
-      print "\r#{' ' * (LOADING_MSG.length)}\r"
-      puts LEGEND_MSG
-      @progress_bar = ProgressBar.create(:total => @job_state.total_files,
-                                         :length => [terminal_length, MAX_LENGTH].min,
-                                         :format => format(bar: :green, title: :white));
-    end
-  end
+    def update payload={}
+      output_gorgon_crash_message payload if gorgon_crashed? payload
 
-  def update_elapsed_time
-    @timer.cancel if @finished
-    @progress_bar.refresh if @progress_bar
-  end
+      create_progress_bar_if_started_job_running
 
-private
-  def gorgon_crashed? payload
-     payload[:type] == "crash" && payload[:action] != "finish"
-  end
+      return if @progress_bar.nil? || @finished
 
-  def output_gorgon_crash_message payload
-    $stderr.puts "\nA #{'crash'.red} occurred at '#{payload[:hostname].colorize Colors::HOST}':"
-    $stderr.puts payload[:stdout].yellow unless payload[:stdout].to_s.strip.length == 0
-    $stderr.puts payload[:stderr].yellow unless payload[:stderr].to_s.strip.length == 0
-    if @progress_bar.nil?
-      print LOADING_MSG         # if still loading, print msg so user won't think the whole job crashed
-    end
-  end
+      failed_files_count = @job_state.failed_files_count
 
-  def format colors
-    # TODO: decide what bar to use
-    #    bar = "%b>%i".colorize(colors[:bar])
-    bar = "%w>%i".colorize(colors[:bar])
-    title = "%t".colorize(colors[:title])
+      @progress_bar.title=" F: #{failed_files_count} H: #{@job_state.total_running_hosts} W: #{@job_state.total_running_workers}"
+      if failed_files_count > 0
+        @progress_bar.format(format(bar: :red, title: :default))
+      end
 
-    "#{title} | [#{bar}] %c/%C %a"
-  end
+      @progress_bar.progress = @job_state.finished_files_count
 
-  def terminal_length
-    `stty size`.split.map { |x| x.to_i }.reverse[0].to_i
-  end
-
-  def print_summary
-    print_failed_tests
-    print_running_files
-    #TODO: print other stats: time, total file, total failures, etc
-  end
-
-  def print_failed_tests
-    @job_state.each_failed_test do |test|
-      puts "\n" + ('*' * 80).magenta #light_red
-      puts("File '#{test[:filename].colorize(Colors::FILENAME)}' failed/crashed at " \
-           + "'#{test[:hostname].colorize(Colors::HOST)}:#{test[:worker_id]}'\n")
-      msg = build_fail_message test[:failures]
-      puts "#{msg}\n"
-    end
-  end
-
-  def build_fail_message failures
-    result = []
-    failures.each do |failure|
-      if failure.is_a?(Hash)
-        result << build_fail_message_from_hash(failure)
-      else
-        result << build_fail_message_from_string(failure)
+      if @job_state.is_job_complete? || @job_state.is_job_cancelled?
+        @finished = true
+        print_summary
       end
     end
 
-    result.join("\n")
-  end
-
-  def print_running_files
-    title = "Unfinished files".yellow
-    puts "\n#{title} - The following files were still running:" if @job_state.total_running_workers > 0
-
-    @job_state.each_running_file do |hostname, filename|
-      filename_str = filename.dup.colorize(Colors::FILENAME)
-      hostname_str = hostname.dup.colorize(Colors::HOST)
-      puts "\t#{filename_str} at '#{hostname_str}'"
+    def create_progress_bar_if_started_job_running
+      if @progress_bar.nil? && @job_state.state == :running
+        print "\r#{' ' * (LOADING_MSG.length)}\r"
+        puts LEGEND_MSG
+        @progress_bar = ProgressBar.create(:total => @job_state.total_files,
+                                           :length => [terminal_length, MAX_LENGTH].min,
+                                           :format => format(bar: :green, title: :white));
+      end
     end
-  end
 
-  def build_fail_message_from_string failure
-    result = failure.gsub(/^Error:/, "Error:".yellow)
-    result.gsub!(/^Failure:/, "Failure:".red)
-    result
-  end
+    def update_elapsed_time
+      @timer.cancel if @finished
+      @progress_bar.refresh if @progress_bar
+    end
 
-  def build_fail_message_from_hash failure
-    result = "#{'Test name'.light_yellow}: #{failure[:test_name]}"
-    result << "\n#{failure[:class].red}" if failure[:class]
-    result << "\n#{'Message:'.light_yellow} \n\t#{failure[:message]}" if failure[:message]
-    result << "\n"
-    result
+    private
+    def gorgon_crashed? payload
+      payload[:type] == "crash" && payload[:action] != "finish"
+    end
+
+    def output_gorgon_crash_message payload
+      $stderr.puts "\nA #{'crash'.red} occurred at '#{payload[:hostname].colorize Colors::HOST}':"
+      $stderr.puts payload[:stdout].yellow unless payload[:stdout].to_s.strip.length == 0
+      $stderr.puts payload[:stderr].yellow unless payload[:stderr].to_s.strip.length == 0
+      if @progress_bar.nil?
+        print LOADING_MSG         # if still loading, print msg so user won't think the whole job crashed
+      end
+    end
+
+    def format colors
+      # TODO: decide what bar to use
+      #    bar = "%b>%i".colorize(colors[:bar])
+      bar = "%w>%i".colorize(colors[:bar])
+      title = "%t".colorize(colors[:title])
+
+      "#{title} | [#{bar}] %c/%C %a"
+    end
+
+    def terminal_length
+      `stty size`.split.map { |x| x.to_i }.reverse[0].to_i
+    end
+
+    def print_summary
+      print_failed_tests
+      print_running_files
+      #TODO: print other stats: time, total file, total failures, etc
+    end
+
+    def print_failed_tests
+      @job_state.each_failed_test do |test|
+        puts "\n" + ('*' * 80).magenta #light_red
+        puts("File '#{test[:filename].colorize(Colors::FILENAME)}' failed/crashed at " \
+             + "'#{test[:hostname].colorize(Colors::HOST)}:#{test[:worker_id]}'\n")
+        msg = build_fail_message test[:failures]
+        puts "#{msg}\n"
+      end
+    end
+
+    def build_fail_message failures
+      result = []
+      failures.each do |failure|
+        if failure.is_a?(Hash)
+          result << build_fail_message_from_hash(failure)
+        else
+          result << build_fail_message_from_string(failure)
+        end
+      end
+
+      result.join("\n")
+    end
+
+    def print_running_files
+      title = "Unfinished files".yellow
+      puts "\n#{title} - The following files were still running:" if @job_state.total_running_workers > 0
+
+      @job_state.each_running_file do |hostname, filename|
+        filename_str = filename.dup.colorize(Colors::FILENAME)
+        hostname_str = hostname.dup.colorize(Colors::HOST)
+        puts "\t#{filename_str} at '#{hostname_str}'"
+      end
+    end
+
+    def build_fail_message_from_string failure
+      result = failure.gsub(/^Error:/, "Error:".yellow)
+      result.gsub!(/^Failure:/, "Failure:".red)
+      result
+    end
+
+    def build_fail_message_from_hash failure
+      result = "#{'Test name'.light_yellow}: #{failure[:test_name]}"
+      result << "\n#{failure[:class].red}" if failure[:class]
+      result << "\n#{'Message:'.light_yellow} \n\t#{failure[:message]}" if failure[:message]
+      result << "\n"
+      result
+    end
   end
 end

--- a/lib/gorgon/rsync_daemon.rb
+++ b/lib/gorgon/rsync_daemon.rb
@@ -1,57 +1,58 @@
 require "tmpdir"
 
-class RsyncDaemon
-  #for now, creates a readonly rsync daemon for the current directory on the mountpath "src"
-  RSYNC_DIR_NAME = "#{Dir.tmpdir}/gorgon_rsync_daemon"
-  RSYNC_PORT = 43434
-  PID_FILE = 'rsync.pid'
+module Gorgon
+  class RsyncDaemon
+    #for now, creates a readonly rsync daemon for the current directory on the mountpath "src"
+    RSYNC_DIR_NAME = "#{Dir.tmpdir}/gorgon_rsync_daemon"
+    RSYNC_PORT = 43434
+    PID_FILE = 'rsync.pid'
 
-  def self.start(directory_bucket)
-    if directory_bucket.nil? || !File.directory?(directory_bucket)
-      $stderr.puts "Please, expecify a valid directory."
-      return false
+    def self.start(directory_bucket)
+      if directory_bucket.nil? || !File.directory?(directory_bucket)
+        $stderr.puts "Please, expecify a valid directory."
+        return false
+      end
+
+      if !port_available?
+        puts port_busy_msg
+        return false
+      end
+
+      Dir.mkdir(RSYNC_DIR_NAME)
+      success = false
+      Dir.chdir(RSYNC_DIR_NAME) do
+        File.write("rsyncd.conf", rsyncd_config_string(directory_bucket))
+
+        success = Kernel.system("rsync --daemon --config rsyncd.conf")
+      end
+
+      success
     end
 
-    if !port_available?
-      puts port_busy_msg
-      return false
+    def self.stop
+      if !File.directory?(RSYNC_DIR_NAME)
+        puts "ERROR: Directory '#{RSYNC_DIR_NAME}' doesn't exists. Maybe rsync daemon is not running!"
+        return false
+      end
+
+      success = nil
+      Dir.chdir(RSYNC_DIR_NAME) do
+        pid = File.read(PID_FILE)
+        success = Kernel.system("kill #{pid}")
+      end
+
+      if success
+        FileUtils::remove_entry_secure(RSYNC_DIR_NAME)
+        return true
+      else
+        return false
+      end
     end
 
-    Dir.mkdir(RSYNC_DIR_NAME)
-    success = false
-    Dir.chdir(RSYNC_DIR_NAME) do
-      File.write("rsyncd.conf", rsyncd_config_string(directory_bucket))
+    private
 
-      success = Kernel.system("rsync --daemon --config rsyncd.conf")
-    end
-
-    success
-  end
-
-  def self.stop
-    if !File.directory?(RSYNC_DIR_NAME)
-      puts "ERROR: Directory '#{RSYNC_DIR_NAME}' doesn't exists. Maybe rsync daemon is not running!"
-      return false
-    end
-
-    success = nil
-    Dir.chdir(RSYNC_DIR_NAME) do
-      pid = File.read(PID_FILE)
-      success = Kernel.system("kill #{pid}")
-    end
-
-    if success
-      FileUtils::remove_entry_secure(RSYNC_DIR_NAME)
-      return true
-    else
-      return false
-    end
-  end
-
-  private
-
-  def self.rsyncd_config_string(directory_bucket)
-    return <<-EOF
+    def self.rsyncd_config_string(directory_bucket)
+      return <<-EOF
 port = #{RSYNC_PORT}
 pid file = #{PID_FILE}
 
@@ -59,23 +60,24 @@ pid file = #{PID_FILE}
   path = #{directory_bucket}
   read only = false
   use chroot = false
-EOF
-  end
-
-  def self.port_available?
-    begin
-      s = TCPServer.new('localhost', RSYNC_PORT)
-      s.close
-      return true
-    rescue Errno::EADDRINUSE => _
-      return false
+      EOF
     end
-  end
 
-  def self.port_busy_msg
-<<-MSG
+    def self.port_available?
+      begin
+        s = TCPServer.new('localhost', RSYNC_PORT)
+        s.close
+        return true
+      rescue Errno::EADDRINUSE => _
+        return false
+      end
+    end
+
+    def self.port_busy_msg
+      <<-MSG
   ERROR: port #{RSYNC_PORT} is being used. Maybe another rsync daemon is running.
   Kill pid in #{RSYNC_DIR_NAME}/#{PID_FILE} or check no other process is using that port."
-MSG
+      MSG
+    end
   end
 end

--- a/lib/gorgon/runtime_file_reader.rb
+++ b/lib/gorgon/runtime_file_reader.rb
@@ -1,37 +1,38 @@
 require 'yajl'
 
-class RuntimeFileReader
+module Gorgon
+  class RuntimeFileReader
 
-  def initialize(configuration)
-    @runtime_filename = configuration[:runtime_file] || ""
-    @globs_of_files = configuration[:files] || [] # e.g. ["spec/file1_spec.rb", "spec/**/*_spec.rb"]
-  end
+    def initialize(configuration)
+      @runtime_filename = configuration[:runtime_file] || ""
+      @globs_of_files = configuration[:files] || [] # e.g. ["spec/file1_spec.rb", "spec/**/*_spec.rb"]
+    end
 
-  def old_files
-    @old_files ||= unless File.file?(@runtime_filename)
-                     []
-                   else
-                     File.open(@runtime_filename, 'r') do |f|
-                       parser = Yajl::Parser.new
-                       hash = parser.parse(f)
-                       hash.nil? ? [] : hash.keys
+    def old_files
+      @old_files ||= unless File.file?(@runtime_filename)
+                       []
+                     else
+                       File.open(@runtime_filename, 'r') do |f|
+                         parser = Yajl::Parser.new
+                         hash = parser.parse(f)
+                         hash.nil? ? [] : hash.keys
+                       end
                      end
-                   end
+    end
+
+    def sorted_files # sorts by 1.) globs, 2.) runtime
+      @globs_of_files.reduce([]) do |memo, glob|
+        memo.concat( sorted_files_by_runtime(Dir[glob]) )
+      end.uniq
+    end
+
+    private
+
+    def sorted_files_by_runtime(current_files = [])
+      (self.old_files+current_files).uniq - (self.old_files-current_files)
+    end
+
+
+
   end
-
-  def sorted_files # sorts by 1.) globs, 2.) runtime
-    @globs_of_files.reduce([]) do |memo, glob|
-      memo.concat( sorted_files_by_runtime(Dir[glob]) )
-    end.uniq
-  end
-
-  private
-
-  def sorted_files_by_runtime(current_files = [])
-    (self.old_files+current_files).uniq - (self.old_files-current_files)
-  end
-
-
-
 end
-

--- a/lib/gorgon/runtime_recorder.rb
+++ b/lib/gorgon/runtime_recorder.rb
@@ -1,36 +1,37 @@
 require 'yajl'
 
-class RuntimeRecorder
-  attr_accessor :records
+module Gorgon
+  class RuntimeRecorder
+    attr_accessor :records
 
-  def initialize(job_state, runtime_filename)
-    @records = {}
-    @job_state = job_state
-    @job_state.add_observer(self)
-    @runtime_filename = runtime_filename || ""
-  end
-
-  def update payload
-    @records[payload[:filename]] = payload[:runtime] if payload[:action] == "finish"
-    self.write_records_to_file if @job_state.is_job_complete?
-  end
-
-  def write_records_to_file
-    return if @runtime_filename.empty?
-    make_directories
-    @records = Hash[@records.sort_by{|filename, runtime| -1*runtime}]
-    File.open(@runtime_filename, 'w') do |f|
-      f.write(Yajl::Encoder.encode(@records, pretty: true))
+    def initialize(job_state, runtime_filename)
+      @records = {}
+      @job_state = job_state
+      @job_state.add_observer(self)
+      @runtime_filename = runtime_filename || ""
     end
+
+    def update payload
+      @records[payload[:filename]] = payload[:runtime] if payload[:action] == "finish"
+      self.write_records_to_file if @job_state.is_job_complete?
+    end
+
+    def write_records_to_file
+      return if @runtime_filename.empty?
+      make_directories
+      @records = Hash[@records.sort_by{|filename, runtime| -1*runtime}]
+      File.open(@runtime_filename, 'w') do |f|
+        f.write(Yajl::Encoder.encode(@records, pretty: true))
+      end
+    end
+
+
+    private
+
+    def make_directories
+      dirname = File.dirname(@runtime_filename)
+      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
+    end
+
   end
-
-
-  private
-
-  def make_directories
-    dirname = File.dirname(@runtime_filename)
-    FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
-  end
-
 end
-

--- a/lib/gorgon/settings/files_content.rb
+++ b/lib/gorgon/settings/files_content.rb
@@ -1,34 +1,36 @@
-module Settings
-  class FilesContent
-    attr_accessor :amqp_host, :file_server_host, :sync_exclude, :files, :originator_log_file,
-      :callbacks, :runtime_file, :failed_files
+module Gorgon
+  module Settings
+    class FilesContent
+      attr_accessor :amqp_host, :file_server_host, :sync_exclude, :files, :originator_log_file,
+        :callbacks, :runtime_file, :failed_files
 
-    TEST_UNIT_GLOB = "test/**/*_test.rb"
-    RSPEC_GLOB = "spec/**/*_spec.rb"
+      TEST_UNIT_GLOB = "test/**/*_test.rb"
+      RSPEC_GLOB = "spec/**/*_spec.rb"
 
-    def initialize
-      @files = []
-      @files << FilesContent::TEST_UNIT_GLOB if Dir.exist?('test')
-      @files << FilesContent::RSPEC_GLOB if Dir.exist?('spec')
-      @runtime_file = 'gorgon-runtime-file.json'
-    end
+      def initialize
+        @files = []
+        @files << FilesContent::TEST_UNIT_GLOB if Dir.exist?('test')
+        @files << FilesContent::RSPEC_GLOB if Dir.exist?('spec')
+        @runtime_file = 'gorgon-runtime-file.json'
+      end
 
-    DEFAULT_HOST = 'localhost'
-    def self.get_amqp_host
-      puts "What's the AMQP host name? (leave blank to use '#{DEFAULT_HOST}') "
-      return get_input_or_default(DEFAULT_HOST)
-    end
+      DEFAULT_HOST = 'localhost'
+      def self.get_amqp_host
+        puts "What's the AMQP host name? (leave blank to use '#{DEFAULT_HOST}') "
+        return get_input_or_default(DEFAULT_HOST)
+      end
 
-    def self.get_file_server_host
-      puts "What's the File Server host name? (leave blank to use '#{DEFAULT_HOST}') "
-      return get_input_or_default(DEFAULT_HOST)
-    end
+      def self.get_file_server_host
+        puts "What's the File Server host name? (leave blank to use '#{DEFAULT_HOST}') "
+        return get_input_or_default(DEFAULT_HOST)
+      end
 
-    private
+      private
 
-    def self.get_input_or_default(default)
-      input = $stdin.gets.chomp
-      (input == '') ? default : input
+      def self.get_input_or_default(default)
+        input = $stdin.gets.chomp
+        (input == '') ? default : input
+      end
     end
   end
 end

--- a/lib/gorgon/settings/initial_files_creator.rb
+++ b/lib/gorgon/settings/initial_files_creator.rb
@@ -1,74 +1,76 @@
 require 'gorgon/settings/simple_project_files_content'
 require 'gorgon/settings/rails_project_files_content'
 
-module Settings
-  class InitialFilesCreator
-    GORGON_JSON_FILE = 'gorgon.json'
+module Gorgon
+  module Settings
+    class InitialFilesCreator
+      GORGON_JSON_FILE = 'gorgon.json'
 
-    # TODO: we may change this, so it knows what Creator to use according to the Gemfile, so the user doesn't need to specify 'framework'
-    def self.run framework
-      if framework.nil?
-        create_files SimpleProjectFilesContent.new
-      elsif framework == 'rails'
-        create_files RailsProjectFilesContent.new
-      else
-        $stderr.puts "Unknown framework"
-        exit(1)
-      end
-    end
-
-    def self.create_files content
-      self.create_gorgon_json content
-    end
-
-    private
-
-    def self.create_gorgon_json content
-      if File.exist? GORGON_JSON_FILE
-        puts "#{GORGON_JSON_FILE} exists. Skipping..."
-        return
+      # TODO: we may change this, so it knows what Creator to use according to the Gemfile, so the user doesn't need to specify 'framework'
+      def self.run framework
+        if framework.nil?
+          create_files SimpleProjectFilesContent.new
+        elsif framework == 'rails'
+          create_files RailsProjectFilesContent.new
+        else
+          $stderr.puts "Unknown framework"
+          exit(1)
+        end
       end
 
-      config = {
-        connection: {host: content.amqp_host},
-        failed_files: content.failed_files,
-        file_server: {host: content.file_server_host},
-        files: content.files,
-        job: {
-          sync: {
-            exclude: content.sync_exclude,
-            rsync_transport: "ssh"
-          }
-        },
-        originator_log_file: content.originator_log_file,
-        runtime_file: content.runtime_file,
-      }
+      def self.create_files content
+        self.create_gorgon_json content
+      end
 
-      if content.callbacks
-        create_callback_file(content)
+      private
 
-        config[:job][:callbacks] = {
-          callbacks_class_file: content.callbacks[:file_name]
+      def self.create_gorgon_json content
+        if File.exist? GORGON_JSON_FILE
+          puts "#{GORGON_JSON_FILE} exists. Skipping..."
+          return
+        end
+
+        config = {
+          connection: {host: content.amqp_host},
+          failed_files: content.failed_files,
+          file_server: {host: content.file_server_host},
+          files: content.files,
+          job: {
+            sync: {
+              exclude: content.sync_exclude,
+              rsync_transport: "ssh"
+            }
+          },
+          originator_log_file: content.originator_log_file,
+          runtime_file: content.runtime_file,
         }
+
+        if content.callbacks
+          create_callback_file(content)
+
+          config[:job][:callbacks] = {
+            callbacks_class_file: content.callbacks[:file_name]
+          }
+        end
+
+        puts "Creating #{GORGON_JSON_FILE}..."
+        File.open(GORGON_JSON_FILE, 'w') do |f|
+          Yajl::Encoder.encode(config, f, :pretty => true, :indent => "  ")
+        end
       end
 
-      puts "Creating #{GORGON_JSON_FILE}..."
-      File.open(GORGON_JSON_FILE, 'w') do |f|
-        Yajl::Encoder.encode(config, f, :pretty => true, :indent => "  ")
-      end
-    end
+      def self.create_callback_file(content)
+        file_path = content.callbacks[:file_name]
+        if File.exist? file_path
+          puts "#{file_path} already exists. Skipping..."
+          return
+        end
 
-    def self.create_callback_file(content)
-      file_path = content.callbacks[:file_name]
-      if File.exist? file_path
-        puts "#{file_path} already exists. Skipping..."
-        return
-      end
-
-      puts "Creating #{file_path}..."
-      FileUtils.mkdir_p(File.dirname(file_path))
-      File.open(file_path, 'w') do |f|
-        f.write content.callbacks[:file_content]
+        puts "Creating #{file_path}..."
+        FileUtils.mkdir_p(File.dirname(file_path))
+        File.open(file_path, 'w') do |f|
+          f.write content.callbacks[:file_content]
+        end
       end
     end
   end

--- a/lib/gorgon/settings/rails_project_files_content.rb
+++ b/lib/gorgon/settings/rails_project_files_content.rb
@@ -1,40 +1,41 @@
 require 'gorgon/settings/files_content'
 
-module Settings
-  class RailsProjectFilesContent < FilesContent
-    def initialize
-      super
-      @amqp_host = FilesContent.get_amqp_host
-      @file_server_host = FilesContent.get_file_server_host
-      @sync_exclude = [".git", ".rvmrc","doc","log","tmp"]
-      @originator_log_file = 'log/gorgon-originator.log'
-      @failed_files = 'gorgon-failed-files.json'
-      create_callbacks
-    end
-
-    private
-
-    def create_callbacks
-      @callbacks = {
-        file_name: "#{get_app_subdir}/gorgon_callbacks/gorgon_callbacks.rb",
-        file_content: callback_file_content
-      }
-    end
-
-    def get_app_subdir
-      if Dir.exist? "test"
-        "test"
-      elsif Dir.exist? "spec"
-        "spec"
-      elsif Dir.exist? "lib"
-        "lib"
-      else
-        ""
+module Gorgon
+  module Settings
+    class RailsProjectFilesContent < FilesContent
+      def initialize
+        super
+        @amqp_host = FilesContent.get_amqp_host
+        @file_server_host = FilesContent.get_file_server_host
+        @sync_exclude = [".git", ".rvmrc","doc","log","tmp"]
+        @originator_log_file = 'log/gorgon-originator.log'
+        @failed_files = 'gorgon-failed-files.json'
+        create_callbacks
       end
-    end
 
-    def callback_file_content
-      <<-'CONTENT'
+      private
+
+      def create_callbacks
+        @callbacks = {
+          file_name: "#{get_app_subdir}/gorgon_callbacks/gorgon_callbacks.rb",
+          file_content: callback_file_content
+        }
+      end
+
+      def get_app_subdir
+        if Dir.exist? "test"
+          "test"
+        elsif Dir.exist? "spec"
+          "spec"
+        elsif Dir.exist? "lib"
+          "lib"
+        else
+          ""
+        end
+      end
+
+      def callback_file_content
+        <<-'CONTENT'
 class GorgonCallbacks < Gorgon::DefaultCallbacks
   BUNDLE_LOG_FILE||="/tmp/gorgon-bundle-install.log "
   def after_sync
@@ -98,7 +99,8 @@ class GorgonCallbacks < Gorgon::DefaultCallbacks
 end
 
 Gorgon.callbacks = GorgonCallbacks.new
-CONTENT
+        CONTENT
+      end
     end
   end
 end

--- a/lib/gorgon/settings/simple_project_files_content.rb
+++ b/lib/gorgon/settings/simple_project_files_content.rb
@@ -1,14 +1,16 @@
 require 'gorgon/settings/files_content'
 
-module Settings
-  class SimpleProjectFilesContent < FilesContent
-    def initialize
-      super
-      @amqp_host = FilesContent.get_amqp_host
-      @file_server_host = FilesContent.get_file_server_host
-      @sync_exclude = [".git", ".rvmrc"]
-      @originator_log_file = 'gorgon-originator.log'
-      @failed_files = 'gorgon-failed-files.json'
+module Gorgon
+  module Settings
+    class SimpleProjectFilesContent < FilesContent
+      def initialize
+        super
+        @amqp_host = FilesContent.get_amqp_host
+        @file_server_host = FilesContent.get_file_server_host
+        @sync_exclude = [".git", ".rvmrc"]
+        @originator_log_file = 'gorgon-originator.log'
+        @failed_files = 'gorgon-failed-files.json'
+      end
     end
   end
 end

--- a/lib/gorgon/shutdown_manager.rb
+++ b/lib/gorgon/shutdown_manager.rb
@@ -1,25 +1,27 @@
-class ShutdownManager
+module Gorgon
+  class ShutdownManager
 
-  def initialize(args)
-    @protocol = args.fetch(:protocol)
-    @job_state = args.fetch(:job_state)
-  end
+    def initialize(args)
+      @protocol = args.fetch(:protocol)
+      @job_state = args.fetch(:job_state)
+    end
 
-  def cancel_job
-    @protocol.cancel_job if @protocol
-  ensure
-    cancel_job_state
-  end
+    def cancel_job
+      @protocol.cancel_job if @protocol
+    ensure
+      cancel_job_state
+    end
 
-  private
+    private
 
-  def cancel_job_state
-    @job_state.cancel if @job_state
-  ensure
-    disconnect_protocol
-  end
+    def cancel_job_state
+      @job_state.cancel if @job_state
+    ensure
+      disconnect_protocol
+    end
 
-  def disconnect_protocol
-    @protocol.disconnect if @protocol
+    def disconnect_protocol
+      @protocol.disconnect if @protocol
+    end
   end
 end

--- a/lib/gorgon/source_tree_syncer.rb
+++ b/lib/gorgon/source_tree_syncer.rb
@@ -1,92 +1,94 @@
 require 'open4'
 
-class SourceTreeSyncer
-  RSYNC_TRANSPORT_SSH = 'ssh'
-  RSYNC_TRANSPORT_ANONYMOUS = 'anonymous'
+module Gorgon
+  class SourceTreeSyncer
+    RSYNC_TRANSPORT_SSH = 'ssh'
+    RSYNC_TRANSPORT_ANONYMOUS = 'anonymous'
 
-  attr_reader :sys_command, :output, :errors
+    attr_reader :sys_command, :output, :errors
 
-  SYS_COMMAND = 'rsync'
-  OPTS = '-azr --timeout=5 --delete'
-  RSH_OPTS = 'ssh -o NumberOfPasswordPrompts=0 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i gorgon.pem'
-  EXCLUDE_OPT = '--exclude'
+    SYS_COMMAND = 'rsync'
+    OPTS = '-azr --timeout=5 --delete'
+    RSH_OPTS = 'ssh -o NumberOfPasswordPrompts=0 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i gorgon.pem'
+    EXCLUDE_OPT = '--exclude'
 
-  def initialize(sync_config)
-    if sync_config
-      @source_tree_path = sync_config[:source_tree_path]
-      @exclude = sync_config[:exclude]
-      @rsync_transport = sync_config[:rsync_transport]
-    end
-  end
-
-  # TODO: rename sync to pull
-  def sync
-    return if blank_source_tree_path?
-
-    @tempdir = Dir.mktmpdir("gorgon")
-    Dir.chdir(@tempdir)
-
-    @sys_command = "#{SYS_COMMAND} #{rsync_options} #{@source_tree_path}/ ."
-
-    execute_command
-  end
-
-  def push
-    return if blank_source_tree_path?
-
-    @sys_command = "#{SYS_COMMAND} #{rsync_options} . #{@source_tree_path}"
-
-    execute_command
-  end
-
-  def success?
-    @exitstatus == 0
-  end
-
-  def remove_temp_dir
-    FileUtils::remove_entry_secure(@tempdir) if @tempdir
-  end
-
-  private
-
-  def execute_command
-    pid, stdin, stdout, stderr = Open4::popen4 @sys_command
-    stdin.close
-
-    ignore, status = Process.waitpid2 pid
-
-    @output, @errors = [stdout, stderr].map { |p| begin p.read ensure p.close end }
-
-    @exitstatus = status.exitstatus
-  end
-
-  def blank_source_tree_path?
-    if @source_tree_path.nil?
-      @errors = "Source tree path cannot be nil. Check your gorgon.json file."
-    elsif @source_tree_path.strip.empty?
-      @errors = "Source tree path cannot be empty. Check your gorgon.json file."
+    def initialize(sync_config)
+      if sync_config
+        @source_tree_path = sync_config[:source_tree_path]
+        @exclude = sync_config[:exclude]
+        @rsync_transport = sync_config[:rsync_transport]
+      end
     end
 
-    if @errors
-      @exitstatus = 1
-      return true
-    else
-      return false
+    # TODO: rename sync to pull
+    def sync
+      return if blank_source_tree_path?
+
+      @tempdir = Dir.mktmpdir("gorgon")
+      Dir.chdir(@tempdir)
+
+      @sys_command = "#{SYS_COMMAND} #{rsync_options} #{@source_tree_path}/ ."
+
+      execute_command
     end
-  end
 
-  def rsync_options
-    if @rsync_transport == RSYNC_TRANSPORT_SSH
-      "#{OPTS} #{exclude_options} --rsh='#{RSH_OPTS}'"
-    else
-      "#{OPTS} #{exclude_options}"
+    def push
+      return if blank_source_tree_path?
+
+      @sys_command = "#{SYS_COMMAND} #{rsync_options} . #{@source_tree_path}"
+
+      execute_command
     end
-  end
 
-  def exclude_options
-    return "" if @exclude.nil? or @exclude.empty?
+    def success?
+      @exitstatus == 0
+    end
 
-    exclude = [""] + @exclude
-    exclude.join(" #{EXCLUDE_OPT} ")
+    def remove_temp_dir
+      FileUtils::remove_entry_secure(@tempdir) if @tempdir
+    end
+
+    private
+
+    def execute_command
+      pid, stdin, stdout, stderr = Open4::popen4 @sys_command
+      stdin.close
+
+      ignore, status = Process.waitpid2 pid
+
+      @output, @errors = [stdout, stderr].map { |p| begin p.read ensure p.close end }
+
+      @exitstatus = status.exitstatus
+    end
+
+    def blank_source_tree_path?
+      if @source_tree_path.nil?
+        @errors = "Source tree path cannot be nil. Check your gorgon.json file."
+      elsif @source_tree_path.strip.empty?
+        @errors = "Source tree path cannot be empty. Check your gorgon.json file."
+      end
+
+      if @errors
+        @exitstatus = 1
+        return true
+      else
+        return false
+      end
+    end
+
+    def rsync_options
+      if @rsync_transport == RSYNC_TRANSPORT_SSH
+        "#{OPTS} #{exclude_options} --rsh='#{RSH_OPTS}'"
+      else
+        "#{OPTS} #{exclude_options}"
+      end
+    end
+
+    def exclude_options
+      return "" if @exclude.nil? or @exclude.empty?
+
+      exclude = [""] + @exclude
+      exclude.join(" #{EXCLUDE_OPT} ")
+    end
   end
 end

--- a/lib/gorgon/worker.rb
+++ b/lib/gorgon/worker.rb
@@ -9,171 +9,173 @@ require "awesome_print"
 require "socket"
 require "benchmark"
 
-module TestRunner
-  def self.run_file filename, test_runner
-    start_t = Time.now
+module Gorgon
+  module TestRunner
+    def self.run_file filename, test_runner
+      start_t = Time.now
 
-    begin
-      failures = test_runner.run_file(filename)
-      length = Time.now - start_t
+      begin
+        failures = test_runner.run_file(filename)
+        length = Time.now - start_t
 
-      if failures.empty?
-        results = {:failures => [], :type => :pass, :runner => test_runner.runner, :time => length}
-      else
-        results = {:failures => failures, :type => :fail, :runner => test_runner.runner,
-          :time => length}
-      end
-    rescue Exception => e
-      results = {:failures => ["Exception: #{e.message}\n#{e.backtrace.join("\n")}"], :type => :crash, :time => (Time.now - start_t)}
-    end
-    return results
-  end
-end
-
-class Worker
-  include GLogger
-
-  class << self
-    def build(worker_id, config)
-      redirect_output_to_files worker_id
-
-      payload = Yajl::Parser.new(:symbolize_keys => true).parse($stdin.read)
-      job_definition = JobDefinition.new(payload)
-
-      connection_config = config[:connection]
-      amqp = AmqpService.new connection_config
-
-      callback_handler = CallbackHandler.new(job_definition.callbacks)
-
-      ENV["GORGON_WORKER_ID"] = worker_id.to_s
-
-      params = {
-        :amqp => amqp,
-        :file_queue_name => job_definition.file_queue_name,
-        :reply_exchange_name => job_definition.reply_exchange_name,
-        :worker_id => worker_id,
-        :callback_handler => callback_handler,
-        :log_file => config[:log_file]
-      }
-
-      new(params)
-    end
-
-    def output_file id, stream
-      "/tmp/gorgon-worker-#{id}.#{stream.to_s}"
-    end
-
-    def redirect_output_to_files worker_id
-      STDOUT.reopen(File.open(output_file(worker_id, :out), 'w'))
-      STDOUT.sync = true
-
-      STDERR.reopen(File.open(output_file(worker_id, :err), 'w'))
-      STDERR.sync = true
-    end
-  end
-
-  def initialize(params)
-    initialize_logger params[:log_file]
-
-    @amqp = params[:amqp]
-    @file_queue_name = params[:file_queue_name]
-    @reply_exchange_name = params[:reply_exchange_name]
-    @worker_id = params[:worker_id]
-    @callback_handler = params[:callback_handler]
-  end
-
-  def work
-    begin
-      log "Running before_start callback..."
-      register_trap_ints        # do it before calling before_start callback!
-      @callback_handler.before_start
-      @cleaned = false
-
-      log "Running files ..."
-      @amqp.start_worker @file_queue_name, @reply_exchange_name do |queue, exchange|
-        while filename = queue.pop
-          exchange.publish make_start_message(filename)
-          log "Running '#{filename}' with Worker: #{@worker_id}"
-          test_results = nil # needed so run_file() inside the Benchmark will use this
-          runtime = Benchmark.realtime do
-            test_results = run_file(filename)
-          end
-          exchange.publish make_finish_message(filename, test_results, runtime)
+        if failures.empty?
+          results = {:failures => [], :type => :pass, :runner => test_runner.runner, :time => length}
+        else
+          results = {:failures => failures, :type => :fail, :runner => test_runner.runner,
+                     :time => length}
         end
+      rescue Exception => e
+        results = {:failures => ["Exception: #{e.message}\n#{e.backtrace.join("\n")}"], :type => :crash, :time => (Time.now - start_t)}
       end
-    rescue Exception => e
+      return results
+    end
+  end
+
+  class Worker
+    include GLogger
+
+    class << self
+      def build(worker_id, config)
+        redirect_output_to_files worker_id
+
+        payload = Yajl::Parser.new(:symbolize_keys => true).parse($stdin.read)
+        job_definition = JobDefinition.new(payload)
+
+        connection_config = config[:connection]
+        amqp = AmqpService.new connection_config
+
+        callback_handler = CallbackHandler.new(job_definition.callbacks)
+
+        ENV["GORGON_WORKER_ID"] = worker_id.to_s
+
+        params = {
+          :amqp => amqp,
+          :file_queue_name => job_definition.file_queue_name,
+          :reply_exchange_name => job_definition.reply_exchange_name,
+          :worker_id => worker_id,
+          :callback_handler => callback_handler,
+          :log_file => config[:log_file]
+        }
+
+        new(params)
+      end
+
+      def output_file id, stream
+        "/tmp/gorgon-worker-#{id}.#{stream.to_s}"
+      end
+
+      def redirect_output_to_files worker_id
+        STDOUT.reopen(File.open(output_file(worker_id, :out), 'w'))
+        STDOUT.sync = true
+
+        STDERR.reopen(File.open(output_file(worker_id, :err), 'w'))
+        STDERR.sync = true
+      end
+    end
+
+    def initialize(params)
+      initialize_logger params[:log_file]
+
+      @amqp = params[:amqp]
+      @file_queue_name = params[:file_queue_name]
+      @reply_exchange_name = params[:reply_exchange_name]
+      @worker_id = params[:worker_id]
+      @callback_handler = params[:callback_handler]
+    end
+
+    def work
+      begin
+        log "Running before_start callback..."
+        register_trap_ints        # do it before calling before_start callback!
+        @callback_handler.before_start
+        @cleaned = false
+
+        log "Running files ..."
+        @amqp.start_worker @file_queue_name, @reply_exchange_name do |queue, exchange|
+          while filename = queue.pop
+            exchange.publish make_start_message(filename)
+            log "Running '#{filename}' with Worker: #{@worker_id}"
+            test_results = nil # needed so run_file() inside the Benchmark will use this
+            runtime = Benchmark.realtime do
+              test_results = run_file(filename)
+            end
+            exchange.publish make_finish_message(filename, test_results, runtime)
+          end
+        end
+      rescue Exception => e
+        clean_up
+        raise e                     # So worker manager can catch it
+      end
       clean_up
-      raise e                     # So worker manager can catch it
     end
-    clean_up
-  end
 
-  private
+    private
 
-  def clean_up
-    return if @cleaned
-    log "Running after_complete callback"
-    @callback_handler.after_complete
-    @cleaned = true
-  end
-
-  def run_file(filename)
-    framework = test_framework(filename).to_s
-
-    require_runner_code_for framework
-    runner_class = get_runner_class_for framework
-
-    TestRunner.run_file(filename, runner_class)
-  end
-
-  def test_framework(filename)
-    if filename =~ /_spec.rb$/i && defined?(RSpec)
-      :rspec
-    elsif defined?(MiniTest) && !test_unit_gem?
-      :mini_test
-    elsif defined?(Test)
-      :test_unit
-    else
-      :unknown
+    def clean_up
+      return if @cleaned
+      log "Running after_complete callback"
+      @callback_handler.after_complete
+      @cleaned = true
     end
-  end
 
-  # Is the user using test-unit gem?
-  def test_unit_gem?
-    gemfile_lock = "./Gemfile.lock"
-    @using_test_unit_gem ||= File.exists?(gemfile_lock) &&
-      File.read(gemfile_lock).scan(/\btest-unit/).any?
-  end
+    def run_file(filename)
+      framework = test_framework(filename).to_s
 
-  def make_start_message(filename)
-    {action: :start, hostname: Socket.gethostname, worker_id: @worker_id, filename: filename}
-  end
+      require_runner_code_for framework
+      runner_class = get_runner_class_for framework
 
-  def make_finish_message(filename, results, runtime)
-    {action: :finish, hostname: Socket.gethostname, worker_id: @worker_id, filename: filename, runtime: runtime}.merge(results)
-  end
+      TestRunner.run_file(filename, runner_class)
+    end
 
-  def require_runner_code_for framework
-    ruby_file = framework.to_s + "_runner"
-    require_relative ruby_file
-  end
+    def test_framework(filename)
+      if filename =~ /_spec.rb$/i && defined?(RSpec)
+        :rspec
+      elsif defined?(MiniTest) && !test_unit_gem?
+        :mini_test
+      elsif defined?(Test)
+        :test_unit
+      else
+        :unknown
+      end
+    end
 
-  def get_runner_class_for framework
-    class_name = camelize(framework) + "Runner"
-    Kernel.const_get(class_name)
-  end
+    # Is the user using test-unit gem?
+    def test_unit_gem?
+      gemfile_lock = "./Gemfile.lock"
+      @using_test_unit_gem ||= File.exists?(gemfile_lock) &&
+        File.read(gemfile_lock).scan(/\btest-unit/).any?
+    end
 
-  def camelize str
-    str.split("_").map(&:capitalize).join
-  end
+    def make_start_message(filename)
+      {action: :start, hostname: Socket.gethostname, worker_id: @worker_id, filename: filename}
+    end
 
-  def register_trap_ints
-    Signal.trap("INT") { ctrl_c }
-    Signal.trap("TERM") { ctrl_c }
-  end
+    def make_finish_message(filename, results, runtime)
+      {action: :finish, hostname: Socket.gethostname, worker_id: @worker_id, filename: filename, runtime: runtime}.merge(results)
+    end
 
-  def ctrl_c
-    clean_up
-    exit
+    def require_runner_code_for framework
+      ruby_file = framework.to_s + "_runner"
+      require_relative ruby_file
+    end
+
+    def get_runner_class_for framework
+      class_name = camelize(framework) + "Runner"
+      Kernel.const_get(class_name)
+    end
+
+    def camelize str
+      str.split("_").map(&:capitalize).join
+    end
+
+    def register_trap_ints
+      Signal.trap("INT") { ctrl_c }
+      Signal.trap("TERM") { ctrl_c }
+    end
+
+    def ctrl_c
+      clean_up
+      exit
+    end
   end
 end

--- a/lib/gorgon/worker_manager.rb
+++ b/lib/gorgon/worker_manager.rb
@@ -7,185 +7,187 @@ require "gorgon/crash_reporter"
 
 require 'eventmachine'
 
-class WorkerManager
-  include PipeForker
-  include GLogger
-  include CrashReporter
+module Gorgon
+  class WorkerManager
+    include PipeForker
+    include GLogger
+    include CrashReporter
 
-  STDOUT_FILE='/tmp/gorgon-worker-mgr.out'
-  STDERR_FILE='/tmp/gorgon-worker-mgr.err'
+    STDOUT_FILE='/tmp/gorgon-worker-mgr.out'
+    STDERR_FILE='/tmp/gorgon-worker-mgr.err'
 
-  def self.build listener_config_file
-    @listener_config_file = listener_config_file
-    config = Configuration.load_configuration_from_file(listener_config_file)
+    def self.build listener_config_file
+      @listener_config_file = listener_config_file
+      config = Configuration.load_configuration_from_file(listener_config_file)
 
-    redirect_output_to_files
+      redirect_output_to_files
 
-    new config
-  end
+      new config
+    end
 
-  def self.redirect_output_to_files
-    STDOUT.reopen(File.open(STDOUT_FILE, 'w'))
-    STDOUT.sync = true
+    def self.redirect_output_to_files
+      STDOUT.reopen(File.open(STDOUT_FILE, 'w'))
+      STDOUT.sync = true
 
-    STDERR.reopen(File.open(STDERR_FILE, 'w'))
-    STDERR.sync = true
-  end
+      STDERR.reopen(File.open(STDERR_FILE, 'w'))
+      STDERR.sync = true
+    end
 
-  def initialize config
-    initialize_logger config[:log_file]
-    log "Worker Manager #{Gorgon::VERSION} initializing"
+    def initialize config
+      initialize_logger config[:log_file]
+      log "Worker Manager #{Gorgon::VERSION} initializing"
 
-    @worker_pids = []
+      @worker_pids = []
 
-    @config = config
+      @config = config
 
-    payload = Yajl::Parser.new(:symbolize_keys => true).parse($stdin.read)
-    @job_definition = JobDefinition.new(payload)
+      payload = Yajl::Parser.new(:symbolize_keys => true).parse($stdin.read)
+      @job_definition = JobDefinition.new(payload)
 
-    @callback_handler = CallbackHandler.new(@job_definition.callbacks)
-    @available_worker_slots = config[:worker_slots]
+      @callback_handler = Gorgon::CallbackHandler.new(@job_definition.callbacks)
+      @available_worker_slots = config[:worker_slots]
 
-    connect
-  end
+      connect
+    end
 
-  def manage
-    fork_workers @available_worker_slots
-  end
+    def manage
+      fork_workers @available_worker_slots
+    end
 
-  private
+    private
 
-  def connect
-    @bunny = GorgonBunny.new(@config[:connection])
-    @bunny.start
-    @reply_exchange = @bunny.exchange(@job_definition.reply_exchange_name, :auto_delete => true)
+    def connect
+      @bunny = GorgonBunny.new(@config[:connection])
+      @bunny.start
+      @reply_exchange = @bunny.exchange(@job_definition.reply_exchange_name, :auto_delete => true)
 
-    @originator_queue = @bunny.queue("", :exclusive => true, :auto_delete => true)
-    exchange = @bunny.exchange("gorgon.worker_managers", :type => :fanout)
-    @originator_queue.bind(exchange)
-  end
+      @originator_queue = @bunny.queue("", :exclusive => true, :auto_delete => true)
+      exchange = @bunny.exchange("gorgon.worker_managers", :type => :fanout)
+      @originator_queue.bind(exchange)
+    end
 
-  def fork_workers n_workers
-    log "Running before_creating_workers callback"
-    @callback_handler.before_creating_workers
+    def fork_workers n_workers
+      log "Running before_creating_workers callback"
+      @callback_handler.before_creating_workers
 
-    log "Forking #{n_workers} worker(s)"
-    EventMachine.run do
-      n_workers.times do
-        fork_a_worker
+      log "Forking #{n_workers} worker(s)"
+      EventMachine.run do
+        n_workers.times do
+          fork_a_worker
+        end
+
+        subscribe_to_originator_queue
+      end
+      @callback_handler.after_creating_workers
+    end
+
+    def fork_a_worker
+      @available_worker_slots -= 1
+      ENV["GORGON_CONFIG_PATH"] = @listener_config_filename
+
+      worker_id = get_worker_id
+      log "Forking Worker #{worker_id}"
+      pid, stdin = pipe_fork do
+        worker = Worker.build(worker_id, @config)
+        worker.work
       end
 
-      subscribe_to_originator_queue
+      @worker_pids << pid
+      stdin.write(@job_definition.to_json)
+      stdin.close
+
+      watcher = proc do
+        ignore, status = Process.waitpid2 pid
+        @worker_pids.delete(pid)
+        log "Worker #{pid} finished"
+        status
+      end
+
+      worker_complete = proc do |status|
+        if status.exitstatus != 0
+          exitstatus = status.exitstatus
+          log_error "Worker #{pid} crashed with exit status #{exitstatus}!"
+
+          # originator may have cancel job and exit, so only try to send message
+          begin
+            out_file = Worker.output_file(worker_id, :out)
+            err_file = Worker.output_file(worker_id, :err)
+
+            msg = report_crash @reply_exchange, :out_file => out_file,
+              :err_file => err_file, :footer_text => footer_text(err_file, out_file)
+            log_error "Process output:\n#{msg}"
+
+            # TODO: find a way to stop the whole system when a worker crashes or do something more clever
+          rescue Exception => e
+            log_error "Exception raised when trying to report crash to originator:"
+            log_error e.message
+            log_error e.backtrace.join("\n")
+          end
+        end
+        on_worker_complete
+      end
+      EventMachine.defer(watcher, worker_complete)
     end
-    @callback_handler.after_creating_workers
-  end
 
-  def fork_a_worker
-    @available_worker_slots -= 1
-    ENV["GORGON_CONFIG_PATH"] = @listener_config_filename
-
-    worker_id = get_worker_id
-    log "Forking Worker #{worker_id}"
-    pid, stdin = pipe_fork do
-      worker = Worker.build(worker_id, @config)
-      worker.work
+    def get_worker_id
+      @worker_id_count = @worker_id_count.nil? ? 1 : @worker_id_count + 1
     end
 
-    @worker_pids << pid
-    stdin.write(@job_definition.to_json)
-    stdin.close
-
-    watcher = proc do
-      ignore, status = Process.waitpid2 pid
-      @worker_pids.delete(pid)
-      log "Worker #{pid} finished"
-      status
+    def on_worker_complete
+      @available_worker_slots += 1
+      on_current_job_complete if current_job_complete?
     end
 
-    worker_complete = proc do |status|
-      if status.exitstatus != 0
-        exitstatus = status.exitstatus
-        log_error "Worker #{pid} crashed with exit status #{exitstatus}!"
+    def current_job_complete?
+      @available_worker_slots == @config[:worker_slots]
+    end
 
-        # originator may have cancel job and exit, so only try to send message
-        begin
-          out_file = Worker.output_file(worker_id, :out)
-          err_file = Worker.output_file(worker_id, :err)
+    def on_current_job_complete
+      log "Job '#{@job_definition.inspect}' completed"
 
-          msg = report_crash @reply_exchange, :out_file => out_file,
-          :err_file => err_file, :footer_text => footer_text(err_file, out_file)
-          log_error "Process output:\n#{msg}"
+      stop
+    end
 
-          # TODO: find a way to stop the whole system when a worker crashes or do something more clever
-        rescue Exception => e
-          log_error "Exception raised when trying to report crash to originator:"
-          log_error e.message
-          log_error e.backtrace.join("\n")
+    def stop
+      EventMachine.stop_event_loop
+      @bunny.stop
+    end
+
+    CANCEL_TIMEOUT = 20
+    def subscribe_to_originator_queue
+
+      originator_watcher = proc do
+        payload = nil
+        while true
+          response = @originator_queue.pop
+          if response != [nil, nil, nil]
+            payload = response[2]
+            break
+          end
+          sleep 0.5
+        end
+        Yajl::Parser.new(:symbolize_keys => true).parse(payload)
+      end
+
+      handle_message = proc do |payload|
+        if payload[:action] == "cancel_job"
+          log "Cancel job received!!!!!!"
+
+          log "Sending 'INT' signal to #{@worker_pids}"
+          Process.kill("INT", *@worker_pids)
+          log "Signal sent"
+
+          EM.add_timer(CANCEL_TIMEOUT) { stop }
+        else
+          EventMachine.defer(originator_watcher, handle_message)
         end
       end
-      on_worker_complete
-    end
-    EventMachine.defer(watcher, worker_complete)
-  end
 
-  def get_worker_id
-    @worker_id_count = @worker_id_count.nil? ? 1 : @worker_id_count + 1
-  end
-
-  def on_worker_complete
-    @available_worker_slots += 1
-    on_current_job_complete if current_job_complete?
-  end
-
-  def current_job_complete?
-    @available_worker_slots == @config[:worker_slots]
-  end
-
-  def on_current_job_complete
-    log "Job '#{@job_definition.inspect}' completed"
-
-    stop
-  end
-
-  def stop
-    EventMachine.stop_event_loop
-    @bunny.stop
-  end
-
-  CANCEL_TIMEOUT = 20
-  def subscribe_to_originator_queue
-
-    originator_watcher = proc do
-      payload = nil
-      while true
-        response = @originator_queue.pop
-        if response != [nil, nil, nil]
-          payload = response[2]
-          break
-        end
-        sleep 0.5
-      end
-      Yajl::Parser.new(:symbolize_keys => true).parse(payload)
+      EventMachine.defer(originator_watcher, handle_message)
     end
 
-    handle_message = proc do |payload|
-      if payload[:action] == "cancel_job"
-        log "Cancel job received!!!!!!"
-
-        log "Sending 'INT' signal to #{@worker_pids}"
-        Process.kill("INT", *@worker_pids)
-        log "Signal sent"
-
-        EM.add_timer(CANCEL_TIMEOUT) { stop }
-      else
-        EventMachine.defer(originator_watcher, handle_message)
-      end
+    def footer_text err_file, out_file
+      "\n***** See #{err_file} and #{out_file} at '#{Socket.gethostname}' for complete output *****\n"
     end
-
-    EventMachine.defer(originator_watcher, handle_message)
-  end
-
-  def footer_text err_file, out_file
-    "\n***** See #{err_file} and #{out_file} at '#{Socket.gethostname}' for complete output *****\n"
   end
 end

--- a/spec/callback_handler_spec.rb
+++ b/spec/callback_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon'
 
-describe CallbackHandler do
+describe Gorgon::CallbackHandler do
 
   let(:config) {
     {
@@ -8,30 +8,30 @@ describe CallbackHandler do
     }
   }
   before do
-    CallbackHandler.any_instance.stub(:load)
+    Gorgon::CallbackHandler.any_instance.stub(:load)
   end
 
   it "loads callback file" do
-    CallbackHandler.any_instance.should_receive(:load).with config[:callbacks_class_file]
+    Gorgon::CallbackHandler.any_instance.should_receive(:load).with config[:callbacks_class_file]
 
-    CallbackHandler.new(config)
+    Gorgon::CallbackHandler.new(config)
   end
 
   it "does not load callback file if it's not specified" do
-    CallbackHandler.any_instance.should_not_receive(:load)
+    Gorgon::CallbackHandler.any_instance.should_not_receive(:load)
 
-    CallbackHandler.new({})
+    Gorgon::CallbackHandler.new({})
   end
 
   context "#before_originate" do
     it "returns value from callbacks#before_originate if it's a string" do
-      handler = CallbackHandler.new(config)
+      handler = Gorgon::CallbackHandler.new(config)
       Gorgon.callbacks.stub(:before_originate).and_return('my_job_id')
       expect(handler.before_originate).to eq('my_job_id')
     end
 
     it "returns nil if callbacks#before_originate did not return a string" do
-      handler = CallbackHandler.new(config)
+      handler = Gorgon::CallbackHandler.new(config)
       Gorgon.callbacks.stub(:before_originate).and_return(Object.new)
       expect(handler.before_originate).to eq(nil)
     end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -27,7 +27,7 @@ describe Gorgon::Command do
       it 'starts the test suite' do
         originator = double('originator')
         originator.should_receive(:originate).with(no_args).and_return(0)
-        Originator.should_receive(:new).with(no_args).and_return(originator)
+        Gorgon::Originator.should_receive(:new).with(no_args).and_return(originator)
         silence_streams($stdout) do
           begin
             Gorgon::Command.run(argv)
@@ -58,7 +58,7 @@ describe Gorgon::Command do
     it 'starts listener' do
       listener = double('listener')
       listener.should_receive(:listen).with(no_args).and_return(true)
-      Listener.should_receive(:new).with(no_args).and_return(listener)
+      Gorgon::Listener.should_receive(:new).with(no_args).and_return(listener)
       silence_streams($stdout) do
         Gorgon::Command.run(['listen'])
       end
@@ -68,13 +68,13 @@ describe Gorgon::Command do
   context 'start rsync' do
     it 'starts rsync for directory' do
       silence_streams($stdout) do
-        RsyncDaemon.should_receive(:start).with('/path/to/directory').and_return(true)
+        Gorgon::RsyncDaemon.should_receive(:start).with('/path/to/directory').and_return(true)
         Gorgon::Command.run(['start_rsync', '/path/to/directory'])
       end
     end
 
     it 'exits with failure if rsync does not start' do
-      RsyncDaemon.should_receive(:start).with(nil).and_return(false)
+      Gorgon::RsyncDaemon.should_receive(:start).with(nil).and_return(false)
       silence_streams($stdout) do
         begin
           Gorgon::Command.run(['start_rsync'])
@@ -89,14 +89,14 @@ describe Gorgon::Command do
 
   context 'stop rsync' do
     it 'stops rsync daemon' do
-      RsyncDaemon.should_receive(:stop).with(no_args).and_return(true)
+      Gorgon::RsyncDaemon.should_receive(:stop).with(no_args).and_return(true)
       silence_streams($stdout) do
         Gorgon::Command.run(['stop_rsync'])
       end
     end
 
     it 'exits with failure if rsync does not stop' do
-      RsyncDaemon.should_receive(:stop).with(no_args).and_return(false)
+      Gorgon::RsyncDaemon.should_receive(:stop).with(no_args).and_return(false)
       silence_streams($stdout) do
         begin
           Gorgon::Command.run(['stop_rsync'])
@@ -112,7 +112,7 @@ describe Gorgon::Command do
     it 'starts worker manager' do
       manager = double('manager')
       ENV['GORGON_CONFIG_PATH'] = '/path/to/config'
-      WorkerManager.should_receive(:build).with('/path/to/config').and_return(manager)
+      Gorgon::WorkerManager.should_receive(:build).with('/path/to/config').and_return(manager)
       manager.should_receive(:manage).with(no_args).and_return(true)
 
       silence_streams($stdout) do
@@ -128,7 +128,7 @@ describe Gorgon::Command do
   context 'ping' do
     it 'pings the listeners' do
       ping_service = double('ping service')
-      PingService.should_receive(:new).with(no_args).and_return(ping_service)
+      Gorgon::PingService.should_receive(:new).with(no_args).and_return(ping_service)
       ping_service.should_receive(:ping_listeners).with(no_args).and_return(true)
 
       silence_streams($stdout) do
@@ -139,7 +139,7 @@ describe Gorgon::Command do
 
   context 'init' do
     it 'creates initial files for provided framework' do
-      Settings::InitialFilesCreator.should_receive(:run).with('rails').and_return(true)
+      Gorgon::Settings::InitialFilesCreator.should_receive(:run).with('rails').and_return(true)
 
       silence_streams($stdout) do
         Gorgon::Command.run(['init', 'rails'])
@@ -149,7 +149,7 @@ describe Gorgon::Command do
 
   context 'install listener' do
     it 'run listener' do
-      ListenerInstaller.should_receive(:install).with(no_args).and_return(true)
+      Gorgon::ListenerInstaller.should_receive(:install).with(no_args).and_return(true)
 
       silence_streams($stdout) do
         Gorgon::Command.run(['install_listener'])
@@ -162,7 +162,7 @@ describe Gorgon::Command do
       gem_service = double('gem service')
       opts = ['install', 'bunny', '--version', '2.0.0']
       gem_service.should_receive(:run).with(opts.join(' ')).and_return(true)
-      GemService.should_receive(:new).with(no_args).and_return(gem_service)
+      Gorgon::GemService.should_receive(:new).with(no_args).and_return(gem_service)
 
       silence_streams($stdout) do
         Gorgon::Command.run(opts.unshift('gem'))

--- a/spec/crash_reporter_spec.rb
+++ b/spec/crash_reporter_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/crash_reporter'
 
-describe "CrashReporter" do
+describe Gorgon::CrashReporter do
   let(:exchange) { double("GorgonBunny Exchange", :publish => nil) }
   let(:info) { {
       :out_file => "stdout_file", :err_file => "stderr_file", :footer_text => "Text"
@@ -8,7 +8,7 @@ describe "CrashReporter" do
 
   let(:container_class) do
     Class.new do
-      extend(CrashReporter)
+      extend(Gorgon::CrashReporter)
     end
   end
 

--- a/spec/failures_printer_spec.rb
+++ b/spec/failures_printer_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/failures_printer'
 
-describe FailuresPrinter do
+describe Gorgon::FailuresPrinter do
   let(:job_state) { double("Job State", :add_observer => nil,
                          :is_job_complete? => true, :is_job_cancelled? => false,
                          :each_failed_test => nil,
@@ -8,7 +8,7 @@ describe FailuresPrinter do
   let(:fd) {double("File descriptor", :write => nil)}
 
   subject do
-    FailuresPrinter.new({}, job_state)
+    Gorgon::FailuresPrinter.new({}, job_state)
   end
 
   it { should respond_to :update }
@@ -16,13 +16,13 @@ describe FailuresPrinter do
   describe "#initialize" do
     it "add its self to observers of job_state" do
       job_state.should_receive(:add_observer)
-      FailuresPrinter.new({}, job_state)
+      Gorgon::FailuresPrinter.new({}, job_state)
     end
   end
 
   describe "#update" do
     before do
-      @printer = FailuresPrinter.new({}, job_state)
+      @printer = Gorgon::FailuresPrinter.new({}, job_state)
     end
 
     context "job is not completed nor cancelled" do
@@ -36,13 +36,13 @@ describe FailuresPrinter do
     context "job is completed" do
       it "outputs failed tests return by job_state#each_failed_test" do
         job_state.stub(:each_failed_test).and_yield({:filename => "file1.rb"}).and_yield({:filename => "file2.rb"})
-        File.should_receive(:open).with(FailuresPrinter::DEFAULT_OUTPUT_FILE, 'w+').and_yield fd
+        File.should_receive(:open).with(Gorgon::FailuresPrinter::DEFAULT_OUTPUT_FILE, 'w+').and_yield fd
         fd.should_receive(:write).with(Yajl::Encoder.encode(["file1.rb", "file2.rb"]))
         @printer.update({})
       end
 
       it "outputs failed tests to 'failed_files' in configuration" do
-        printer = FailuresPrinter.new({failed_files: 'a-file-somewhere.json'}, job_state)
+        printer = Gorgon::FailuresPrinter.new({failed_files: 'a-file-somewhere.json'}, job_state)
         File.should_receive(:open).with('a-file-somewhere.json', 'w+')
         printer.update({})
       end
@@ -56,7 +56,7 @@ describe FailuresPrinter do
 
       it "outputs failed tests return by job_state#each_failed_test" do
         job_state.stub(:each_failed_test).and_yield({:filename => "file1.rb"}).and_yield({:filename => "file2.rb"})
-        File.should_receive(:open).with(FailuresPrinter::DEFAULT_OUTPUT_FILE, 'w+').and_yield fd
+        File.should_receive(:open).with(Gorgon::FailuresPrinter::DEFAULT_OUTPUT_FILE, 'w+').and_yield fd
         fd.should_receive(:write).once.with(Yajl::Encoder.encode(["file1.rb", "file2.rb"]))
         @printer.update({})
       end

--- a/spec/gem_command_handler_spec.rb
+++ b/spec/gem_command_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/gem_command_handler'
 
-describe GemCommandHandler do
+describe Gorgon::GemCommandHandler do
   let(:exchange) { double("GorgonBunny Exchange", :publish => nil) }
   let(:bunny) { double("GorgonBunny", :exchange => exchange, :stop => nil) }
 
@@ -15,7 +15,7 @@ describe GemCommandHandler do
 
   describe "#handle" do
     before do
-      @handler = GemCommandHandler.new bunny
+      @handler = Gorgon::GemCommandHandler.new bunny
       @running_response = {:type => :running_command, :hostname => Socket.gethostname}
       stub_methods
     end

--- a/spec/gem_service_spec.rb
+++ b/spec/gem_service_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/gem_service'
 
-describe GemService do
+describe Gorgon::GemService do
   let(:configuration){ {:connection => {:host => "host"}, :originator_log_file => "file.log"}}
   let(:protocol) { double("OriginatorProtocol", :connect => nil,
                         :receive_payloads => nil, :disconnect => nil,
@@ -9,12 +9,12 @@ describe GemService do
 
   before do
     $stdout.stub(:write)
-    GemService.any_instance.stub(:load_configuration_from_file).and_return configuration
+    Gorgon::GemService.any_instance.stub(:load_configuration_from_file).and_return configuration
     EM.stub(:run).and_yield
     EM.stub(:add_periodic_timer).and_yield
-    OriginatorLogger.stub(:new).and_return logger
-    OriginatorProtocol.stub(:new).and_return(protocol)
-    @service = GemService.new
+    Gorgon::OriginatorLogger.stub(:new).and_return logger
+    Gorgon::OriginatorProtocol.stub(:new).and_return(protocol)
+    @service = Gorgon::GemService.new
     @command = "install"
   end
 
@@ -31,7 +31,7 @@ describe GemService do
     end
 
     it "adds a periodic timer that checks if there is any listener running command" do
-      EM.should_receive(:add_periodic_timer).with(GemService::TIMEOUT)
+      EM.should_receive(:add_periodic_timer).with(Gorgon::GemService::TIMEOUT)
       @service.run @command
     end
 

--- a/spec/host_state_spec.rb
+++ b/spec/host_state_spec.rb
@@ -1,13 +1,13 @@
 require 'gorgon/host_state'
 
-describe HostState do
+describe Gorgon::HostState do
   it { should respond_to(:file_started).with(2).arguments }
   it { should respond_to(:file_finished).with(2).arguments }
   it { should respond_to(:each_running_file).with(0).argument }
   it { should respond_to(:total_running_workers).with(0).argument }
 
   before do
-    @host_state = HostState.new
+    @host_state = Gorgon::HostState.new
   end
 
   describe "#total_workers_running" do

--- a/spec/job_definition_spec.rb
+++ b/spec/job_definition_spec.rb
@@ -1,7 +1,7 @@
 require 'gorgon/job_definition'
 require 'yajl'
 
-describe JobDefinition do
+describe Gorgon::JobDefinition do
   before(:all) do
     @json_parser = Yajl::Parser.new(:symbolize_keys => true)
   end
@@ -16,7 +16,7 @@ describe JobDefinition do
         :callbacks => {}
       }
 
-      jd = JobDefinition.new(expected_hash)
+      jd = Gorgon::JobDefinition.new(expected_hash)
 
       @json_parser.parse(jd.to_json).should == expected_hash
     end

--- a/spec/job_state_spec.rb
+++ b/spec/job_state_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/job_state'
 
-describe JobState do
+describe Gorgon::JobState do
   let(:payload) {
     {:hostname => "host-name", :worker_id => "worker1", :filename => "path/file.rb",
       :type => "pass", :failures => []}
@@ -8,7 +8,7 @@ describe JobState do
 
   let (:host_state){ double("Host State", :file_started => nil, :file_finished => nil)}
 
-  subject { JobState.new 5 }
+  subject { Gorgon::JobState.new 5 }
   it { should respond_to :failed_files_count }
   it { should respond_to :finished_files_count }
   it { should respond_to(:file_started).with(1).argument }
@@ -23,7 +23,7 @@ describe JobState do
   it { should respond_to :is_job_cancelled? }
 
   before do
-    @job_state = JobState.new 5
+    @job_state = Gorgon::JobState.new 5
   end
 
   describe "#initialize" do
@@ -57,19 +57,19 @@ describe JobState do
     end
 
     it "creates a new HostState object if this is the first file started by 'hostname'" do
-      HostState.should_receive(:new).and_return host_state
+      Gorgon::HostState.should_receive(:new).and_return host_state
       @job_state.file_started(payload)
     end
 
     it "doesn't create a new HostState object if this is not the first file started by 'hostname'" do
-      HostState.stub(:new).and_return host_state
+      Gorgon::HostState.stub(:new).and_return host_state
       @job_state.file_started(payload)
-      HostState.should_not_receive(:new)
+      Gorgon::HostState.should_not_receive(:new)
       @job_state.file_started(payload)
     end
 
     it "calls #file_started on HostState object representing 'hostname'" do
-      HostState.stub(:new).and_return host_state
+      Gorgon::HostState.stub(:new).and_return host_state
       host_state.should_receive(:file_started).with("worker_id", "file_name")
       @job_state.file_started({:hostname => "hostname",
                                 :worker_id => "worker_id",
@@ -85,7 +85,7 @@ describe JobState do
 
   describe "#file_finished" do
     before do
-      HostState.stub(:new).and_return host_state
+      Gorgon::HostState.stub(:new).and_return host_state
       @job_state.file_started payload
     end
 
@@ -124,7 +124,7 @@ describe JobState do
     end
 
     it "tells to the proper HostState object that a file finished in that host" do
-      HostState.stub(:new).and_return host_state
+      Gorgon::HostState.stub(:new).and_return host_state
       @job_state.file_started({:hostname => "hostname",
                                 :worker_id => "worker_id",
                                 :filename => "file_name"})

--- a/spec/originator_logger_spec.rb
+++ b/spec/originator_logger_spec.rb
@@ -1,11 +1,11 @@
 require 'gorgon/originator_logger'
 
-describe OriginatorLogger do
+describe Gorgon::OriginatorLogger do
   before do
-    OriginatorLogger.any_instance.stub(:initialize_logger)
+    Gorgon::OriginatorLogger.any_instance.stub(:initialize_logger)
   end
 
-  let (:originator_logger) { OriginatorLogger.new "" }
+  let (:originator_logger) { Gorgon::OriginatorLogger.new "" }
 
   describe "#log_message" do
     it "prints start messages" do

--- a/spec/originator_protocol_spec.rb
+++ b/spec/originator_protocol_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/originator_protocol'
 
-describe OriginatorProtocol do
+describe Gorgon::OriginatorProtocol do
   let(:connection) { double("Connection", :disconnect => nil, :on_closed => nil)}
   let(:queue) { double("Queue", :bind => nil, :subscribe => nil, :name => "queue", :purge => nil,
                      :delete => nil) }
@@ -12,7 +12,7 @@ describe OriginatorProtocol do
   before do
     AMQP.stub(:connect).and_return connection
     AMQP::Channel.stub(:new).and_return channel
-    @originator_p = OriginatorProtocol.new logger
+    @originator_p = Gorgon::OriginatorProtocol.new logger
     @conn_information = {:host => "host"}
   end
 
@@ -72,20 +72,20 @@ describe OriginatorProtocol do
 
     it "adds queue's names to job_definition and fanout using 'gorgon.jobs' exchange" do
       channel.should_receive(:fanout).with("gorgon.jobs")
-      expected_job_definition = JobDefinition.new
+      expected_job_definition = Gorgon::JobDefinition.new
       expected_job_definition.file_queue_name = "queue"
       expected_job_definition.reply_exchange_name = "exchange"
 
       exchange.should_receive(:publish).with(expected_job_definition.to_json)
-      @originator_p.publish_job_to_all JobDefinition.new
+      @originator_p.publish_job_to_all Gorgon::JobDefinition.new
     end
 
     it "uses cluster_id in job_queue_name, when it is specified" do
-      originator_p = connect_and_publish_files(OriginatorProtocol.new(logger, "cluster1"))
+      originator_p = connect_and_publish_files(Gorgon::OriginatorProtocol.new(logger, "cluster1"))
 
       channel.should_receive(:fanout).with("gorgon.jobs.cluster1")
 
-      originator_p.publish_job_to_all JobDefinition.new
+      originator_p.publish_job_to_all Gorgon::JobDefinition.new
     end
   end
 
@@ -96,13 +96,13 @@ describe OriginatorProtocol do
 
     it "publishes the job to the specified listener queue" do
       expected_listener_queue_name = "abcd1234"
-      expected_job_definition = JobDefinition.new
+      expected_job_definition = Gorgon::JobDefinition.new
       expected_job_definition.file_queue_name = "queue"
       expected_job_definition.reply_exchange_name = "exchange"
 
       exchange.should_receive(:publish).with(expected_job_definition.to_json, {:routing_key => expected_listener_queue_name})
 
-      @originator_p.publish_job_to_one(JobDefinition.new, expected_listener_queue_name)
+      @originator_p.publish_job_to_one(Gorgon::JobDefinition.new, expected_listener_queue_name)
     end
   end
 

--- a/spec/ping_service_spec.rb
+++ b/spec/ping_service_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/ping_service'
 
-describe "PingService" do
+describe Gorgon::PingService do
   describe "#ping_listeners" do
     let(:configuration){ {:connection => {:host => "host"}, :originator_log_file => "file.log"}}
     let(:protocol) { double("OriginatorProtocol", :connect => nil, :ping => nil,
@@ -10,23 +10,23 @@ describe "PingService" do
 
     before do
       $stdout.stub(:write)
-      PingService.any_instance.stub(:load_configuration_from_file).and_return configuration
+      Gorgon::PingService.any_instance.stub(:load_configuration_from_file).and_return configuration
       EventMachine.stub(:run).and_yield
       EM.stub(:add_timer).and_yield
-      OriginatorLogger.stub(:new).and_return logger
+      Gorgon::OriginatorLogger.stub(:new).and_return logger
     end
 
     it "connnects and calls OriginatorProtocol#send_message_to_listeners" do
-      OriginatorProtocol.should_receive(:new).once.ordered.and_return(protocol)
+      Gorgon::OriginatorProtocol.should_receive(:new).once.ordered.and_return(protocol)
       protocol.should_receive(:connect).once.ordered.with({:host => "host"}, anything)
       protocol.should_receive(:send_message_to_listeners).once.ordered
-      PingService.new.ping_listeners
+      Gorgon::PingService.new.ping_listeners
     end
 
     context "after sending ping messages" do
       before do
-        OriginatorProtocol.stub(:new).and_return(protocol)
-        @service = PingService.new
+        Gorgon::OriginatorProtocol.stub(:new).and_return(protocol)
+        @service = Gorgon::PingService.new
       end
 
       it "adds an Event machine timer" do

--- a/spec/pipe_forker_spec.rb
+++ b/spec/pipe_forker_spec.rb
@@ -1,12 +1,12 @@
 require 'gorgon/pipe_forker'
 
-describe PipeForker do
+describe Gorgon::PipeForker do
   let(:io_pipe) { double("IO object", :close => nil)}
   let(:pipe) {double("Pipe", :write => io_pipe)}
 
   let(:container_class) do
     Class.new do
-      extend(PipeForker)
+      extend(Gorgon::PipeForker)
     end
   end
 

--- a/spec/progress_bar_view_spec.rb
+++ b/spec/progress_bar_view_spec.rb
@@ -1,23 +1,23 @@
 require 'gorgon/progress_bar_view'
 require 'gorgon/job_state'
 
-describe ProgressBarView do
+describe Gorgon::ProgressBarView do
   before do
     EventMachine::PeriodicTimer.stub(:new)
   end
 
   describe "#initialize" do
     it "adds itself to observers of job_state" do
-      job_state = JobState.new 1
+      job_state = Gorgon::JobState.new 1
       job_state.should_receive(:add_observer)
-      ProgressBarView.new job_state
+      Gorgon::ProgressBarView.new job_state
     end
   end
 
   describe "#show" do
     before do
-      job_state = JobState.new 1
-      @progress_bar_view = ProgressBarView.new job_state
+      job_state = Gorgon::JobState.new 1
+      @progress_bar_view = Gorgon::ProgressBarView.new job_state
     end
 
     it "prints in console gorgon's version and that is loading workers" do
@@ -38,9 +38,9 @@ describe ProgressBarView do
 
     before do
       ProgressBar.stub(:create).and_return progress_bar
-      @job_state = JobState.new 2
+      @job_state = Gorgon::JobState.new 2
       @job_state.stub(:state).and_return :running
-      @progress_bar_view = ProgressBarView.new @job_state
+      @progress_bar_view = Gorgon::ProgressBarView.new @job_state
       $stdout.stub(:write)
       @progress_bar_view.show
     end

--- a/spec/rsync_daemon_spec.rb
+++ b/spec/rsync_daemon_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/rsync_daemon'
 
-describe RsyncDaemon do
+describe Gorgon::RsyncDaemon do
   let(:directory) {'/lol/hax'}
 
   before(:each) do
@@ -10,7 +10,7 @@ describe RsyncDaemon do
     File.stub(:write => 100, :read => "12345", :directory? => true)
     FileUtils.stub(:remove_entry_secure => nil)
     TCPServer.stub(:new => double('TCPServer', :close => nil))
-    @r = RsyncDaemon
+    @r = Gorgon::RsyncDaemon
   end
 
   it "starts the rsync daemon" do
@@ -20,8 +20,8 @@ describe RsyncDaemon do
   end
 
   it "creates a directory in temporary dir for the configuration and pid files" do
-    Dir.should_receive(:mkdir).with(RsyncDaemon::RSYNC_DIR_NAME)
-    Dir.should_receive(:chdir).with(RsyncDaemon::RSYNC_DIR_NAME)
+    Dir.should_receive(:mkdir).with(Gorgon::RsyncDaemon::RSYNC_DIR_NAME)
+    Dir.should_receive(:chdir).with(Gorgon::RsyncDaemon::RSYNC_DIR_NAME)
 
     @r.start(directory)
   end

--- a/spec/runtime_file_reader_spec.rb
+++ b/spec/runtime_file_reader_spec.rb
@@ -1,7 +1,7 @@
 require 'gorgon/runtime_file_reader'
 require 'yajl'
 
-describe RuntimeFileReader do
+describe Gorgon::RuntimeFileReader do
 
   let(:old_files){ ["old_a.rb", "old_b.rb", "old_c.rb", "old_d.rb"] }
 
@@ -10,14 +10,14 @@ describe RuntimeFileReader do
 
     it "should read runtime_file" do
       File.stub(:file?).and_return(true)
-      runtime_file_reader = RuntimeFileReader.new(configuration)
+      runtime_file_reader = Gorgon::RuntimeFileReader.new(configuration)
       File.should_receive(:open).with(configuration[:runtime_file], 'r')
       runtime_file_reader.old_files
     end
 
     it "should return empty array if runtime_file is invalid" do
       File.should_receive(:file?).and_return(false)
-      runtime_file_reader = RuntimeFileReader.new(configuration)
+      runtime_file_reader = Gorgon::RuntimeFileReader.new(configuration)
       File.should_not_receive(:open)
       runtime_file_reader.old_files
     end
@@ -28,7 +28,7 @@ describe RuntimeFileReader do
     let(:configuration){ {runtime_file: "runtime_file.json"} }
 
     before do
-      @runtime_file_reader = RuntimeFileReader.new(configuration)
+      @runtime_file_reader = Gorgon::RuntimeFileReader.new(configuration)
       @runtime_file_reader.stub(:old_files).and_return old_files
     end
 
@@ -52,7 +52,7 @@ describe RuntimeFileReader do
     let(:configuration){ {files: ["glob_1", "glob_2", "glob_3"]} }
 
     before do
-      @runtime_file_reader = RuntimeFileReader.new(configuration)
+      @runtime_file_reader = Gorgon::RuntimeFileReader.new(configuration)
       @runtime_file_reader.stub(:old_files).and_return old_files
     end
 

--- a/spec/runtime_recorder_spec.rb
+++ b/spec/runtime_recorder_spec.rb
@@ -2,15 +2,15 @@ require 'gorgon/job_state'
 require 'gorgon/runtime_recorder'
 require 'yajl'
 
-describe RuntimeRecorder do
+describe Gorgon::RuntimeRecorder do
 
   let (:runtime_filename){ "runtime_file.json" }
 
   describe "#initialize" do
     it "adds itself to observers of job_state and sets records as empty" do
-      job_state = JobState.new 1
+      job_state = Gorgon::JobState.new 1
       job_state.should_receive(:add_observer)
-      runtime_recorder = RuntimeRecorder.new job_state, runtime_filename
+      runtime_recorder = Gorgon::RuntimeRecorder.new job_state, runtime_filename
       expect(runtime_recorder.records).to eq({})
     end
   end
@@ -19,8 +19,8 @@ describe RuntimeRecorder do
   describe "#update" do
     let(:payload){ {filename: "file_spec.rb", runtime: 1.23, action: "finish"} }
     before do
-      @job_state = JobState.new 1
-      @runtime_recorder = RuntimeRecorder.new @job_state, nil
+      @job_state = Gorgon::JobState.new 1
+      @runtime_recorder = Gorgon::RuntimeRecorder.new @job_state, nil
     end
 
     it "should record if a file finished" do
@@ -53,11 +53,11 @@ describe RuntimeRecorder do
     let(:sample_records){ {"zero.rb" => 0.23, "one.rb" => 1.23, "two.rb" => 2.23} }
 
     before do
-      @job_state = JobState.new 1
+      @job_state = Gorgon::JobState.new 1
     end
 
     it "should not write if no file is given" do
-      runtime_recorder = RuntimeRecorder.new @job_state, nil
+      runtime_recorder = Gorgon::RuntimeRecorder.new @job_state, nil
       runtime_recorder.records = sample_records
       file = mock('file')
       File.should_not_receive(:open).and_yield(file)
@@ -66,7 +66,7 @@ describe RuntimeRecorder do
     end
 
     it "should write sorted records to the given file" do
-      runtime_recorder = RuntimeRecorder.new @job_state, runtime_filename
+      runtime_recorder = Gorgon::RuntimeRecorder.new @job_state, runtime_filename
       runtime_recorder.records = sample_records
       file = mock('file')
       File.should_receive(:open).with(runtime_filename, 'w').and_yield(file)

--- a/spec/shutdown_manager_spec.rb
+++ b/spec/shutdown_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/shutdown_manager'
 
-describe ShutdownManager do
+describe Gorgon::ShutdownManager do
   let(:protocol){ double("Originator Protocol", :cancel_job => nil, :disconnect => nil)}
 
   let(:job_state){ double("JobState", cancel: nil)}
@@ -35,6 +35,6 @@ describe ShutdownManager do
         protocol: protocol,
         job_state: job_state
     }
-    ShutdownManager.new(defaults.merge(args))
+    Gorgon::ShutdownManager.new(defaults.merge(args))
   end
 end

--- a/spec/source_tree_syncer_spec.rb
+++ b/spec/source_tree_syncer_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/source_tree_syncer'
 
-describe SourceTreeSyncer.new(source_tree_path: "") do
+describe Gorgon::SourceTreeSyncer.new(source_tree_path: "") do
   it { should respond_to :sync }
   it { should respond_to :push }
   it { should respond_to :sys_command }
@@ -15,7 +15,7 @@ describe SourceTreeSyncer.new(source_tree_path: "") do
   let(:status) { double("Process Status", :exitstatus => 0)}
 
   before do
-    @syncer = SourceTreeSyncer.new(source_tree_path: "path/to/source")
+    @syncer = Gorgon::SourceTreeSyncer.new(source_tree_path: "path/to/source")
     stub_utilities_methods
   end
 
@@ -29,7 +29,7 @@ describe SourceTreeSyncer.new(source_tree_path: "") do
 
     context "invalid source_tree_path" do
       it "gives error if source_tree_path is empty string" do
-        syncer = SourceTreeSyncer.new(source_tree_path: "  ")
+        syncer = Gorgon::SourceTreeSyncer.new(source_tree_path: "  ")
         Dir.should_not_receive(:mktmpdir)
         syncer.sync
         syncer.success?.should be_false
@@ -37,7 +37,7 @@ describe SourceTreeSyncer.new(source_tree_path: "") do
       end
 
       it "gives error if source_tree_path is nil" do
-        syncer = SourceTreeSyncer.new nil
+        syncer = Gorgon::SourceTreeSyncer.new nil
         Dir.should_not_receive(:mktmpdir)
         syncer.sync
         syncer.success?.should be_false
@@ -53,7 +53,7 @@ describe SourceTreeSyncer.new(source_tree_path: "") do
       end
 
       it "exclude files when they are specified" do
-        @syncer = SourceTreeSyncer.new(source_tree_path: "path/to/source", exclude: ["log", ".git"])
+        @syncer = Gorgon::SourceTreeSyncer.new(source_tree_path: "path/to/source", exclude: ["log", ".git"])
         Open4.should_receive(:popen4).with(/--exclude log --exclude .git/)
         @syncer.sync
       end
@@ -98,7 +98,7 @@ describe SourceTreeSyncer.new(source_tree_path: "") do
 
   describe "#remove_temp_dir" do
     before do
-      @syncer = SourceTreeSyncer.new(source_tree_path: "path/to/source")
+      @syncer = Gorgon::SourceTreeSyncer.new(source_tree_path: "path/to/source")
       stub_utilities_methods
       @syncer.sync
     end

--- a/spec/worker_manager_spec.rb
+++ b/spec/worker_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'gorgon/worker_manager'
 
-describe WorkerManager do
+describe Gorgon::WorkerManager do
   let(:exchange) { double("GorgonBunny Exchange", :publish => nil) }
   let(:queue) { double("Queue", :bind => nil, :subscribe => nil, :delete => nil,
                      :pop => {:payload => :queue_empty}) }
@@ -13,7 +13,7 @@ describe WorkerManager do
     STDOUT.stub(:sync)
     STDERR.stub(:sync)
     GorgonBunny.stub(:new).and_return(bunny)
-    Configuration.stub(:load_configuration_from_file).and_return({})
+    Gorgon::Configuration.stub(:load_configuration_from_file).and_return({})
     EventMachine.stub(:run).and_yield
   end
 
@@ -22,31 +22,31 @@ describe WorkerManager do
       STDIN.should_receive(:read).and_return '{"source_tree_path":"path/to/source",
              "sync":{"exclude":["log"]}}'
 
-      Configuration.should_receive(:load_configuration_from_file).with("file.json").and_return({})
+      Gorgon::Configuration.should_receive(:load_configuration_from_file).with("file.json").and_return({})
 
-      WorkerManager.build "file.json"
+      Gorgon::WorkerManager.build "file.json"
     end
 
     it "redirect output to a file since writing to a pipe may block when pipe is full" do
-      File.should_receive(:open).with(WorkerManager::STDOUT_FILE, 'w').and_return(:file1)
+      File.should_receive(:open).with(Gorgon::WorkerManager::STDOUT_FILE, 'w').and_return(:file1)
       STDOUT.should_receive(:reopen).with(:file1)
-      File.should_receive(:open).with(WorkerManager::STDERR_FILE, 'w').and_return(:file2)
+      File.should_receive(:open).with(Gorgon::WorkerManager::STDERR_FILE, 'w').and_return(:file2)
       STDERR.should_receive(:reopen).with(:file2)
-      WorkerManager.build ""
+      Gorgon::WorkerManager.build ""
     end
 
     it "use STDOUT#sync to flush output immediately so if an exception happens, we can grab the last\
 few lines of output and send it to originator. Order matters" do
       STDOUT.should_receive(:reopen).once.ordered
       STDOUT.should_receive(:sync=).with(true).once.ordered
-      WorkerManager.build ""
+      Gorgon::WorkerManager.build ""
     end
 
     it "use STDERR#sync to flush output immediately so if an exception happens, we can grab the last\
 few lines of output and send it to originator. Order matters" do
       STDERR.should_receive(:reopen).once.ordered
       STDERR.should_receive(:sync=).with(true).once.ordered
-      WorkerManager.build ""
+      Gorgon::WorkerManager.build ""
     end
   end
 end


### PR DESCRIPTION
This will prevent Gorgon from polluting the global namespace and also
potentially changing user constants.