### PR TITLE
Print seed in failed RSpec tests

### DIFF
--- a/lib/gorgon/gorgon_rspec_formatter.rb
+++ b/lib/gorgon/gorgon_rspec_formatter.rb
@@ -6,38 +6,39 @@ module RSpec
     module Formatters
       class GorgonRspecFormatter < BaseFormatter
         if Formatters.respond_to? :register
-          Formatters.register self, :message, :stop, :close
+          Formatters.register self, :message, :stop, :close, :seed
         end
 
         attr_reader :output
 
         def initialize(output)
           super
+          @execution_results = []
           @failures = []
+          @seed = nil
         end
 
         def message(_notification)
         end
 
         def stop(notification=nil)
-          @failures += failures(notification).map do |failure|
-            {
-              test_name: "#{failure.full_description}: line #{failure.metadata[:line_number]}",
-              description: failure.description,
-              full_description: failure.full_description,
-              status: :failed,
-              file_path: failure.metadata[:file_path],
-              line_number: failure.metadata[:line_number],
-            }.tap do |hash|
-              exception = failure.exception
-              unless exception.nil?
-                hash[:class] = exception.class.name
-                hash[:message] = exception.message
-                hash[:location] = exception.backtrace
-              end
-            end
-          end
+          @execution_results += failures(notification)
         end
+
+        def seed(seed_notification)
+          return unless seed_notification.seed_used?
+
+          @seed = seed_notification.seed
+        end
+
+        def close(_notification=nil)
+          @failures += transform_execution_results
+
+          output.write @failures.to_json
+          output.close if IO === output && output != $stdout
+        end
+
+        private
 
         def failures(notification)
           if !notification.nil?
@@ -47,9 +48,26 @@ module RSpec
           end
         end
 
-        def close(_notification=nil)
-          output.write @failures.to_json
-          output.close if IO === output && output != $stdout
+        def transform_execution_results
+          @execution_results.map do |failure|
+            {
+              test_name: "#{failure.full_description}: line #{failure.metadata[:line_number]}",
+              description: failure.description,
+              full_description: failure.full_description,
+              status: :failed,
+              file_path: failure.metadata[:file_path],
+              line_number: failure.metadata[:line_number]
+            }.tap do |hash|
+              exception = failure.exception
+              unless exception.nil?
+                hash[:class] = exception.class.name
+                hash[:message] = exception.message
+                hash[:location] = exception.backtrace
+              end
+
+              hash[:seed] = @seed if @seed
+            end
+          end
         end
       end
     end

--- a/lib/gorgon/gorgon_rspec_formatter.rb
+++ b/lib/gorgon/gorgon_rspec_formatter.rb
@@ -13,7 +13,6 @@ module RSpec
 
         def initialize(output)
           super
-          @execution_results = []
           @failures = []
           @seed = nil
         end
@@ -22,7 +21,7 @@ module RSpec
         end
 
         def stop(notification=nil)
-          @execution_results += failures(notification)
+          @failures += failures(notification)
         end
 
         def seed(seed_notification)
@@ -32,9 +31,7 @@ module RSpec
         end
 
         def close(_notification=nil)
-          @failures += transform_execution_results
-
-          output.write @failures.to_json
+          output.write serialize_failures(@failures).to_json
           output.close if IO === output && output != $stdout
         end
 
@@ -48,8 +45,8 @@ module RSpec
           end
         end
 
-        def transform_execution_results
-          @execution_results.map do |failure|
+        def serialize_failures(failures)
+          failures.map do |failure|
             {
               test_name: "#{failure.full_description}: line #{failure.metadata[:line_number]}",
               description: failure.description,

--- a/lib/gorgon/gorgon_rspec_formatter.rb
+++ b/lib/gorgon/gorgon_rspec_formatter.rb
@@ -25,8 +25,6 @@ module RSpec
         end
 
         def seed(seed_notification)
-          return unless seed_notification.seed_used?
-
           @seed = seed_notification.seed
         end
 

--- a/lib/gorgon/progress_bar_view.rb
+++ b/lib/gorgon/progress_bar_view.rb
@@ -100,6 +100,7 @@ module Gorgon
 
         message_parts = [
           "File '#{test[:filename].colorize(Colors::FILENAME)}'",
+          print_seed?(test) ? "(seed: #{test[:seed]})" : "",
           " failed/crashed at ",
           "'#{test[:hostname].colorize(Colors::HOST)}:#{test[:worker_id]}'",
           "\n"
@@ -109,6 +110,10 @@ module Gorgon
         msg = build_fail_message test[:failures]
         puts "#{msg}\n"
       end
+    end
+
+    def print_seed?(test_payload)
+      test_payload.key?(:seed) && !test_payload[:seed].empty?
     end
 
     def build_fail_message failures

--- a/lib/gorgon/progress_bar_view.rb
+++ b/lib/gorgon/progress_bar_view.rb
@@ -97,8 +97,15 @@ module Gorgon
     def print_failed_tests
       @job_state.each_failed_test do |test|
         puts "\n" + ('*' * 80).magenta #light_red
-        puts("File '#{test[:filename].colorize(Colors::FILENAME)}' failed/crashed at " \
-             + "'#{test[:hostname].colorize(Colors::HOST)}:#{test[:worker_id]}'\n")
+
+        message_parts = [
+          "File '#{test[:filename].colorize(Colors::FILENAME)}'",
+          " failed/crashed at ",
+          "'#{test[:hostname].colorize(Colors::HOST)}:#{test[:worker_id]}'",
+          "\n"
+        ]
+        puts message_parts.join("")
+
         msg = build_fail_message test[:failures]
         puts "#{msg}\n"
       end

--- a/spec/gorgon_rspec_formatter_spec.rb
+++ b/spec/gorgon_rspec_formatter_spec.rb
@@ -16,15 +16,24 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
   let(:output) { double("StringIO", :write => nil, :close => nil) }
   let(:formatter) { RSpec::Core::Formatters::GorgonRspecFormatter.new(output) }
 
-  it "returns an array of hashes when there are failures" do
-    allow(formatter).to receive(:examples).and_return([example, fail_example])
+  context "when there are failures" do
+    it "returns an array of hashes" do
+      allow(formatter).to receive(:examples).and_return([example, fail_example])
 
-    expected_result = [{:test_name => "Full_Description: line 2", :description => "description",
-                         :full_description => "Full_Description", :status => "failed",
-                         :file_path => "path/to/file", :line_number => 2}]
-    expect(output).to receive(:write).with(expected_result.to_json)
+      expected_result = [
+        {
+          test_name: "Full_Description: line 2",
+          description: "description",
+          full_description: "Full_Description",
+          status: "failed",
+          file_path: "path/to/file",
+          line_number: 2
+        }
+      ]
+      expect(output).to receive(:write).with(expected_result.to_json)
 
-    run_formatter(formatter)
+      run_formatter(formatter)
+    end
   end
 
   it "returns an empty array when all examples pass" do

--- a/spec/gorgon_rspec_formatter_spec.rb
+++ b/spec/gorgon_rspec_formatter_spec.rb
@@ -14,48 +14,46 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
                          :backtrace => "backtrace")}
 
   let(:output) { double("StringIO", :write => nil, :close => nil) }
-
-  before do
-    @formatter = RSpec::Core::Formatters::GorgonRspecFormatter.new(output)
-  end
+  let(:formatter) { RSpec::Core::Formatters::GorgonRspecFormatter.new(output) }
 
   it "returns an array of hashes when there are failures" do
-    allow(@formatter).to receive(:examples).and_return([example, fail_example])
+    allow(formatter).to receive(:examples).and_return([example, fail_example])
 
     expected_result = [{:test_name => "Full_Description: line 2", :description => "description",
                          :full_description => "Full_Description", :status => "failed",
                          :file_path => "path/to/file", :line_number => 2}]
     expect(output).to receive(:write).with(expected_result.to_json)
-    run_formatter(@formatter)
+
+    run_formatter(formatter)
   end
 
   it "returns an empty array when all examples pass" do
-    allow(@formatter).to receive(:examples).and_return([example, example])
+    allow(formatter).to receive(:examples).and_return([example, example])
 
     expect(output).to receive(:write).with("[]")
 
-    run_formatter(@formatter)
+    run_formatter(formatter)
   end
 
   it "returns an empty array when all examples are pending" do
     allow(example).to receive(:execution_result).and_return(:status => "pending")
-    allow(@formatter).to receive(:examples).and_return([example, example])
+    allow(formatter).to receive(:examples).and_return([example, example])
 
     expect(output).to receive(:write).with("[]")
 
-    run_formatter(@formatter)
+    run_formatter(formatter)
   end
 
   it "returns exception details if there is an exception" do
     allow(fail_example).to receive(:exception).and_return(exception)
-    allow(@formatter).to receive(:examples).and_return([fail_example])
+    allow(formatter).to receive(:examples).and_return([fail_example])
     expected_result = [{:test_name => "Full_Description: line 2", :description => "description",
                          :full_description => "Full_Description", :status => "failed",
                          :file_path => "path/to/file", :line_number => 2, :class => Object.name,
                          :message => "some msg", :location => "backtrace"}]
     expect(output).to receive(:write).with(expected_result.to_json)
 
-    run_formatter(@formatter)
+    run_formatter(formatter)
   end
 
   it "uses RSpec 3 API when available" do
@@ -67,7 +65,7 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
         :file_path => "path/to/file", :line_number => 2}]
     expect(output).to receive(:write).with(expected_result.to_json)
 
-    run_formatter(@formatter, stop_notification: notification)
+    run_formatter(formatter, stop_notification: notification)
   end
 
   def run_formatter(formatter, stop_notification: nil)

--- a/spec/gorgon_rspec_formatter_spec.rb
+++ b/spec/gorgon_rspec_formatter_spec.rb
@@ -19,6 +19,7 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
   context "when there are failures" do
     it "returns an array of hashes" do
       allow(formatter).to receive(:examples).and_return([example, fail_example])
+      seed_notification = double("SeedNotification", seed_used?: true, seed: "_seed_value_")
 
       expected_result = [
         {
@@ -27,12 +28,13 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
           full_description: "Full_Description",
           status: "failed",
           file_path: "path/to/file",
-          line_number: 2
+          line_number: 2,
+          seed: "_seed_value_"
         }
       ]
       expect(output).to receive(:write).with(expected_result.to_json)
 
-      run_formatter(formatter)
+      run_formatter(formatter, seed_notification: seed_notification)
     end
   end
 
@@ -77,8 +79,14 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
     run_formatter(formatter, stop_notification: notification)
   end
 
-  def run_formatter(formatter, stop_notification: nil)
+  def run_formatter(formatter, stop_notification: nil, seed_notification: nil)
     formatter.stop(stop_notification)
+
+    # Note: seed notification may actually be sent before or after stop!
+    if seed_notification
+      formatter.seed(seed_notification)
+    end
+
     formatter.close
   end
 end

--- a/spec/gorgon_rspec_formatter_spec.rb
+++ b/spec/gorgon_rspec_formatter_spec.rb
@@ -1,7 +1,5 @@
 require 'gorgon/gorgon_rspec_formatter'
 
-BaseFormatter = RSpec::Core::Formatters::GorgonRspecFormatter
-
 describe RSpec::Core::Formatters::GorgonRspecFormatter do
   let(:example) {double("Example", :description => "description",
                       :full_description => "Full_Description",
@@ -18,7 +16,7 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
   let(:output) { double("StringIO", :write => nil, :close => nil) }
 
   before do
-    @formatter = BaseFormatter.new(output)
+    @formatter = RSpec::Core::Formatters::GorgonRspecFormatter.new(output)
   end
 
   it "returns an array of hashes when there are failures" do

--- a/spec/gorgon_rspec_formatter_spec.rb
+++ b/spec/gorgon_rspec_formatter_spec.rb
@@ -28,16 +28,15 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
                          :full_description => "Full_Description", :status => "failed",
                          :file_path => "path/to/file", :line_number => 2}]
     expect(output).to receive(:write).with(expected_result.to_json)
-    @formatter.stop
-    @formatter.close
+    run_formatter(@formatter)
   end
 
   it "returns an empty array when all examples pass" do
     allow(@formatter).to receive(:examples).and_return([example, example])
 
     expect(output).to receive(:write).with("[]")
-    @formatter.stop
-    @formatter.close
+
+    run_formatter(@formatter)
   end
 
   it "returns an empty array when all examples are pending" do
@@ -45,8 +44,8 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
     allow(@formatter).to receive(:examples).and_return([example, example])
 
     expect(output).to receive(:write).with("[]")
-    @formatter.stop
-    @formatter.close
+
+    run_formatter(@formatter)
   end
 
   it "returns exception details if there is an exception" do
@@ -57,8 +56,8 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
                          :file_path => "path/to/file", :line_number => 2, :class => Object.name,
                          :message => "some msg", :location => "backtrace"}]
     expect(output).to receive(:write).with(expected_result.to_json)
-    @formatter.stop
-    @formatter.close
+
+    run_formatter(@formatter)
   end
 
   it "uses RSpec 3 API when available" do
@@ -69,7 +68,12 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
         :full_description => "Full_Description", :status => "failed",
         :file_path => "path/to/file", :line_number => 2}]
     expect(output).to receive(:write).with(expected_result.to_json)
-    @formatter.stop(notification)
-    @formatter.close
+
+    run_formatter(@formatter, stop_notification: notification)
+  end
+
+  def run_formatter(formatter, stop_notification: nil)
+    formatter.stop(stop_notification)
+    formatter.close
   end
 end

--- a/spec/gorgon_rspec_formatter_spec.rb
+++ b/spec/gorgon_rspec_formatter_spec.rb
@@ -19,7 +19,7 @@ describe RSpec::Core::Formatters::GorgonRspecFormatter do
   context "when there are failures" do
     it "returns an array of hashes" do
       allow(formatter).to receive(:examples).and_return([example, fail_example])
-      seed_notification = double("SeedNotification", seed_used?: true, seed: "_seed_value_")
+      seed_notification = double("SeedNotification", seed: "_seed_value_")
 
       expected_result = [
         {

--- a/spec/progress_bar_view_spec.rb
+++ b/spec/progress_bar_view_spec.rb
@@ -80,6 +80,26 @@ describe Gorgon::ProgressBarView do
       @progress_bar_view.update
     end
 
+    context "when seed is present" do
+      let(:payload_with_seed) do
+        {
+          filename: "path/file.rb",
+          hostname: "host",
+          failures: ["Failure messages"],
+          seed: "1234"
+        }
+      end
+
+      it "prints the seed" do
+        allow(@job_state).to receive(:each_failed_test).and_yield(payload_with_seed)
+        allow(@job_state).to receive(:is_job_complete?).and_return :true
+
+        expect($stdout).to receive(:write).with(%r(seed: 1234))
+
+        @progress_bar_view.update
+      end
+    end
+
     context "when job is cancelled" do
       before do
         @progress_bar_view.update


### PR DESCRIPTION
We often experience transient failures in specs that fail in Gorgon but pass when run locally. This PR includes the seed with the data extracted from failing tests with RSpec.

This should help a lot by providing a seed to use when running the `--bisect` RSpec option.

If there's anything else you would like to see, let me know!